### PR TITLE
Perl-script passes `bench' literal quotes, which it doesn't expect.

### DIFF
--- a/tests/check.pl
+++ b/tests/check.pl
@@ -46,7 +46,7 @@ sub flush_problems {
 
     if ($#list_of_problems >= 0) {
 	for (@list_of_problems) {
-	    $problist = "$problist --verify '$_'";
+	    $problist = "$problist --verify $_";
 	}
 	print "Executing \"$program $options $problist\"\n" 
 	    if $verbose;


### PR DESCRIPTION
Currently, when "make check" is called, the 'bench.exe' program fails with an 'assert' (out of format) error.

_________________________ _Current_ output start _________________________
`[..]
Making check in tests
make[1]: Entering directory '/d/Dev-Cpp/zztmp/_math/FFTW/fftw-3.3.3/tests'
make  check-local
make[2]: Entering directory '/d/Dev-Cpp/zztmp/_math/FFTW/fftw-3.3.3/tests'
perl -w ./check.pl  -r -c=30 -v 'pwd'/bench.exe
Executing "d:/Dev-Cpp/zztmp/_math/FFTW/fftw-3.3.3/tests/bench.exe --verbose=1   --verify 'okd9e11x5e00v24' --verify 'ikd9e11x5e00v24' [..]"
bench: problem.c:96: assertion failed: isdigit(*s)
FAILED d:/Dev-Cpp/zztmp/_math/FFTW/fftw-3.3.3/tests/bench.exe:  --verify 'okd9e11x5e00v24' --verify 'ikd9e11x5e00v24' [..]
Makefile:598: recipe for target 'check-local' failed
[..]
make: *** [check-recursive] Error 1`
_________________________ _Current_ output end _________________________

_________________________ _Patched_ output start _________________________
`[..]
Making check in tests
make[1]: Entering directory '/d/Dev-Cpp/zztmp/_math/FFTW/fftw-3.3.3/tests'
make  check-local
make[2]: Entering directory '/d/Dev-Cpp/zztmp/_math/FFTW/fftw-3.3.3/tests'
perl -w ./check.pl  -r -c=30 -v 'pwd'/bench.exe
Executing "d:/Dev-Cpp/zztmp/_math/FFTW/fftw-3.3.3/tests/bench.exe --verbose=1   --verify obrd6x13x10 --verify ibrd6x13x10 [..]"
obrd6x13x10 3.8593e-016 8.90453e-016 6.30425e-016
ibrd6x13x10 4.91469e-016 1.14487e-015 5.82203e-016
[..]
--------------------------------.------------------------------
         FFTW threaded transforms passed basic tests!
--------------------------------.------------------------------`
_________________________ _Patched_ output end _________________________
