### PR TITLE
avoid segfaults due to double free

### DIFF
--- a/mpi/transpose-pairwise.c
+++ b/mpi/transpose-pairwise.c
@@ -350,6 +350,7 @@ nada:
      X(plan_destroy_internal)(*cld3);
      X(plan_destroy_internal)(*cld2rest);
      X(plan_destroy_internal)(*cld2);
+     *cld2 = *cld2rest = *cld3 = NULL;
      return 0;
 }
 


### PR DESCRIPTION
If fftw_mpi_mkplans_posttranspose() fails, the plans cld3, cld2rest,
and cld2 are destroyed at nada and must be set to NULL. Otherwise,
a second destroy at nada in mkplan() will cause a segfault.
