### PR TITLE
add indent to requirements

### DIFF
--- a/README
+++ b/README
@@ -26,7 +26,7 @@ If you have downloaded an official release, please read chapter
      make install
 
 If you are using the git repository, install ocaml, autoconf,
-automake, and libtool, and execute the bootstrap.sh script.  Most of
+automake, indent and libtool, and execute the bootstrap.sh script.  Most of
 the source code of fftw is generated automatically, and this script
 generates all the required source files.
 


### PR DESCRIPTION
Without indent, `make` reports errors in a directory called codelets.  
It also reports `/bin/bash: indent: command not found` not far away.

For my Ubuntu 14.04 flavor, a simple `sudo apt-get install indent` made `make` work as expected.

I hope this pull request does not enter in the world of obvious-spam-pull requests. I though it might be useful to non-specialists like me. 