### PR TITLE
Fixed unique token generation in genfft

### DIFF
--- a/genfft/unique.ml
+++ b/genfft/unique.ml
@@ -21,18 +21,14 @@
 
 (* repository of unique tokens *)
 
-type unique = Unique of unit
+type unique = int
 
-(* this depends on the compiler not being too smart *)
+let id = ref 0
+
 let make () =
-  let make_aux x = Unique x in
-  make_aux ()
+  id := !id + 1;
+  !id
 
-(* note that the obvious definition
+let same a b =
+  a = b
 
-      let make () = Unique ()
-
-   fails *)
-
-let same (a : unique) (b : unique) =
-  (a == b)


### PR DESCRIPTION
OCaml became smart enough to break this trick. It inlines `make_aux` starting from 4.02.0, and all generated tokens are the same.

```ocaml
(* this depends on the compiler not being too smart *)
let make () =
  let make_aux x = Unique x in
  make_aux ()

(* note that the obvious definition
      let make () = Unique ()
   fails *)
```

It seems this led to generation of wrong codelets (at least genfft built with OCaml 4.01.0 and 4.02.3 generated different codelets).

I've implemented "legal" unique token generation.
