### PR TITLE
Update configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -392,8 +392,8 @@ case "${ax_cv_c_compiler_vendor}" in
                 ;;
                 *)
 	        if test "$have_neon" = "yes" -a "x$NEON_CFLAGS" = x; then
-	            AX_CHECK_COMPILER_FLAGS(-mfpu=neon, [NEON_CFLAGS="-mfpu=neon"],
-			[AC_MSG_ERROR([Need a version of gcc with -mfpu=neon])])
+	            AX_CHECK_COMPILER_FLAGS(-mfpu=neon, [NEON_CFLAGS="-mfpu=neon -mfloat-abi=softfp"],
+			[AC_MSG_ERROR([Need a version of gcc with -mfpu=neon -mfloat-abi=softfp])])
 	        fi
                 ;;
         esac


### PR DESCRIPTION
While cross compiling for Android with NEON enabled it complained about the missing -mfloat option.

I am not really sure if this is fully correct but it fix my build.