### PR TITLE
#include <intrin.h> in threads.c for windows build

### DIFF
--- a/threads/threads.c
+++ b/threads/threads.c
@@ -163,6 +163,7 @@ static void os_static_mutex_unlock(os_static_mutex_t *s) { pthread_mutex_unlock(
 #define INT magnus_ab_INTegro_seclorum_nascitur_ordo
 #include <windows.h>
 #include <process.h>
+#include <intrin.h>
 #undef INT
 
 typedef HANDLE os_mutex_t;


### PR DESCRIPTION
otherwise an i686-w64-mingw32 cross compile is giving
```
libtool: link: i686-w64-mingw32-gcc -march=pentium4 -m32  -std=gnu99 -shared  -Wl,--whole-archive kernel/.libs/libkernel.a dft/.libs/libdft.a dft/scalar/.libs/libdft_scalar.a dft/scalar/codelets/.libs/libdft_scalar_codelets.a rdft/.libs/librdft.a rdft/scalar/.libs/librdft_scalar.a rdft/scalar/r2cf/.libs/librdft_scalar_r2cf.a rdft/scalar/r2cb/.libs/librdft_scalar_r2cb.a rdft/scalar/r2r/.libs/librdft_scalar_r2r.a reodft/.libs/libreodft.a api/.libs/libapi.a simd-support/.libs/libsimd_support.a simd-support/.libs/libsimd_sse2_nonportable.a dft/simd/avx/.libs/libdft_avx_codelets.a rdft/simd/avx/.libs/librdft_avx_codelets.a threads/.libs/libfftw3f_threads.a -Wl,--no-whole-archive   -march=pentium4 -m32 -O3 -mtune=native -malign-double -Wl,--stack -Wl,8388608   -o .libs/libfftw3f-3.dll -Wl,--enable-auto-image-base -Xlinker --out-implib -Xlinker .libs/libfftw3f.dll.a
libtool: link: i686-w64-mingw32-gcc -march=pentium4 -m32  -std=gnu99 -shared  -Wl,--whole-archive kernel/.libs/libkernel.a dft/.libs/libdft.a dft/scalar/.libs/libdft_scalar.a dft/scalar/codelets/.libs/libdft_scalar_codelets.a rdft/.libs/librdft.a rdft/scalar/.libs/librdft_scalar.a rdft/scalar/r2cf/.libs/librdft_scalar_r2cf.a rdft/scalar/r2cb/.libs/librdft_scalar_r2cb.a rdft/scalar/r2r/.libs/librdft_scalar_r2r.a reodft/.libs/libreodft.a api/.libs/libapi.a simd-support/.libs/libsimd_support.a simd-support/.libs/libsimd_sse2_nonportable.a dft/simd/avx/.libs/libdft_avx_codelets.a rdft/simd/avx/.libs/librdft_avx_codelets.a threads/.libs/libfftw3_threads.a -Wl,--no-whole-archive   -march=pentium4 -m32 -O3 -mtune=native -malign-double -Wl,--stack -Wl,8388608   -o .libs/libfftw3-3.dll -Wl,--enable-auto-image-base -Xlinker --out-implib -Xlinker .libs/libfftw3.dll.a
threads/.libs/libfftw3_threads.a(libfftw3_threads_la-threads.o):threads.c:(.text+0x121): undefined reference to `_mm_pause'
threads/.libs/libfftw3_threads.a(libfftw3_threads_la-threads.o):threads.c:(.text+0x581): undefined reference to `_mm_pause'
collect2: error: ld returned 1 exit status
threads/.libs/libfftw3f_threads.a(libfftw3f_threads_la-threads.o):threads.c:(.text+0x121): undefined reference to `_mm_pause'
threads/.libs/libfftw3f_threads.a(libfftw3f_threads_la-threads.o):threads.c:(.text+0x581): undefined reference to `_mm_pause'
collect2: error: ld returned 1 exit status
make[4]: *** [Makefile:627: libfftw3f.la] Error 1
make[4]: *** [Makefile:627: libfftw3.la] Error 1
make[3]: *** [Makefile:672: all-recursive] Error 1
make[2]: *** [Makefile:536: all] Error 2
make[3]: *** [Makefile:672: all-recursive] Error 1
make[1]: *** [/home/Tony/julia32/deps/fftw.mk:46: scratch/fftw-3.3.5-single/build-compiled] Error 2
make[1]: *** Waiting for unfinished jobs....
make[2]: *** [Makefile:536: all] Error 2
make[1]: *** [/home/Tony/julia32/deps/fftw.mk:46: scratch/fftw-3.3.5-double/build-compiled] Error 2
make: *** [Makefile:81: julia-deps] Error 2
```