### PR TITLE
Update simd-vsx.h to support building with IBM XLC

### DIFF
--- a/simd-support/simd-vsx.h
+++ b/simd-support/simd-vsx.h
@@ -165,7 +165,11 @@ static inline V VBYI(V x)
   const vector unsigned char perm = { 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00, 0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, 0x99, 0x88 };
 #    endif
   const V                    pmpm = vec_mergel(vec_splats((R)0.0),-(vec_splats((R)0.0)));
+#ifdef __ibmxl__
+  return (V)__vpermxor((vector unsigned char)x,(vector unsigned char)pmpm,perm);
+#else
   return (V)__builtin_crypto_vpermxor((vector unsigned char)x,(vector unsigned char)pmpm,perm);
+#endif
 #elif defined(__POWER8_VECTOR__) && (defined(__ibmxl__) || (defined(__GNUC__) && !defined(__LITTLE_ENDIAN__)))
 #    ifdef FFTW_SINGLE
   const vector unsigned char perm = { 0x44, 0x55, 0x66, 0x77, 0x00, 0x11, 0x22, 0x33, 0xCC, 0xDD, 0xEE, 0xFF, 0x88, 0x99, 0xAA, 0xBB };


### PR DESCRIPTION
defined(__POWER8_VECTOR__) && defined(__GNUC__) && defined(__LITTLE_ENDIAN__) is true for IBM XLC compiler for which we should use the intrinsic __vpermxor instead of __builtin_crypto_vpermxor.