### PR TITLE
Avoid trying to use CLOCK_SGI_CYCLE on Android

### DIFF
--- a/kernel/cycle.h
+++ b/kernel/cycle.h
@@ -438,7 +438,7 @@ INLINE_ELAPSED(__inline)
 #endif
 /*----------------------------------------------------------------*/
 /* SGI/Irix */
-#if defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_SGI_CYCLE) && !defined(HAVE_TICK_COUNTER)
+#if defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_SGI_CYCLE) && !defined(HAVE_TICK_COUNTER) && !defined(__ANDROID__)
 typedef struct timespec ticks;
 
 static inline ticks getticks(void)


### PR DESCRIPTION
The Android headers defines `CLOCK_SGI_CYCLE` but the call fails at runtime as it's not implemented.

Combined with getticks() not checking the return value of clock_gettime() this currently causes bogus values to be returned from getticks() on an unpatched Android build.