### PR TITLE
Fix ARMV7-A cycle counter detection

### DIFF
--- a/kernel/cycle.h
+++ b/kernel/cycle.h
@@ -515,7 +515,7 @@ INLINE_ELAPSED(inline)
 #endif
 #endif /* HAVE_MIPS_ZBUS_TIMER */
 
-#if defined(__ARM_ARCH_7A__) && defined(ARMV7A_HAS_CNTVCT)
+#if defined(__ARM_ARCH_7A__) && defined(HAVE_ARMV7A_CNTVCT)
 typedef uint64_t ticks;
 static inline ticks getticks(void)
 {


### PR DESCRIPTION
Check for the correct pre-processor define HAVE_ARMV7A_CNTVCT from
config.h (instead of ARMV7A_HAS_CNTVCT) to fix the detection of the
cycle counter for ARMv7-A in the configure script (and actually use it
in the built library).

Without this fix, even the following ./configure call:

  ./configure --enable-neon --enable-single --enable-armv7a-cntvct \
  --host=arm-linux-gnueabihf --disable-fortran \
  CC="arm-linux-gnueabihf-gcc -march=armv7-a"

will emit the warning:

  checking whether a cycle counter is available... no
  ***************************************************************
  WARNING: No cycle counter found.  FFTW will use ESTIMATE mode
           for all plans.  See the manual for more information.
  ***************************************************************

With this fix applied, ./configure will correctly detect the cycle
counter register:

  ...
  checking whether a cycle counter is available... yes
  ...