### PR TITLE
Add user cmake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,367 @@
+cmake_minimum_required (VERSION 3.0)
+
+if (NOT DEFINED CMAKE_BUILD_TYPE)
+  set (CMAKE_BUILD_TYPE Release CACHE STRING "Build type")
+endif ()
+
+project (fftw)
+
+if (POLICY CMP0042)
+  cmake_policy (SET CMP0042 NEW)
+endif ()
+
+option (BUILD_SHARED_LIBS "Build shared libraries" ON)
+option (BUILD_TESTS "Build tests" ON)
+
+option (ENABLE_OPENMP "Use OpenMP for multithreading" OFF)
+option (ENABLE_THREADS "Use pthread for multithreading" OFF)
+option (WITH_COMBINED_THREADS "Merge thread library" OFF)
+
+option (ENABLE_FLOAT "single-precision" OFF)
+option (ENABLE_LONG_DOUBLE "long-double precision" OFF)
+option (ENABLE_QUAD_PRECISION "quadruple-precision" OFF)
+
+option (ENABLE_SSE "Compile with SSE instruction set support" OFF)
+option (ENABLE_SSE2 "Compile with SSE2 instruction set support" OFF)
+option (ENABLE_AVX "Compile with AVX instruction set support" OFF)
+option (ENABLE_AVX2 "Compile with AVX2 instruction set support" OFF)
+
+set (LIBRARY_PATH lib${LIB_SUFFIX})
+
+
+include (CheckIncludeFile)
+check_include_file (alloca.h         HAVE_ALLOCA_H)
+check_include_file (altivec.h        HAVE_ALTIVEC_H)
+check_include_file (c_asm.h          HAVE_C_ASM_H)
+check_include_file (dlfcn.h          HAVE_DLFCN_H)
+check_include_file (intrinsics.h     HAVE_INTRINSICS_H)
+check_include_file (inttypes.h       HAVE_INTTYPES_H)
+check_include_file (libintl.h        HAVE_LIBINTL_H)
+check_include_file (limits.h         HAVE_LIMITS_H)
+check_include_file (mach/mach_time.h HAVE_MACH_MACH_TIME_H)
+check_include_file (malloc.h         HAVE_MALLOC_H)
+check_include_file (memory.h         HAVE_MEMORY_H)
+check_include_file (stddef.h         HAVE_STDDEF_H)
+check_include_file (stdint.h         HAVE_STDINT_H)
+check_include_file (stdlib.h         HAVE_STDLIB_H)
+check_include_file (string.h         HAVE_STRING_H)
+check_include_file (strings.h        HAVE_STRINGS_H)
+check_include_file (sys/types.h      HAVE_SYS_TYPES_H)
+check_include_file (sys/time.h       HAVE_SYS_TIME_H)
+check_include_file (sys/stat.h       HAVE_SYS_STAT_H)
+check_include_file (sys/sysctl.h     HAVE_SYS_SYSCTL_H)
+check_include_file (time.h           HAVE_TIME_H)
+check_include_file (uintptr.h        HAVE_UINTPTR_H)
+check_include_file (unistd.h         HAVE_UNISTD_H)
+if (HAVE_TIME_H AND HAVE_SYS_TIME_H)
+  set (TIME_WITH_SYS_TIME TRUE)
+endif ()
+
+include (CheckPrototypeDefinition) 
+check_prototype_definition (drand48 "double drand48 (void)" "0" stdlib.h HAVE_DECL_DRAND48)
+check_prototype_definition (srand48 "void srand48(long int seedval)" "0" stdlib.h HAVE_DECL_SRAND48)
+check_prototype_definition (cosl "long double cosl( long double arg )" "0" math.h HAVE_DECL_COSL)
+check_prototype_definition (sinl "long double sinl( long double arg )" "0" math.h HAVE_DECL_SINL)
+check_prototype_definition (memalign "void *memalign(size_t alignment, size_t size)" "0" malloc.h HAVE_DECL_MEMALIGN)
+check_prototype_definition (posix_memalign "int posix_memalign(void **memptr, size_t alignment, size_t size)" "0" stdlib.h HAVE_DECL_POSIX_MEMALIGN)
+
+include (CheckSymbolExists)
+check_symbol_exists (clock_gettime time.h HAVE_CLOCK_GETTIME)
+check_symbol_exists (gettimeofday sys/time.h HAVE_GETTIMEOFDAY)
+check_symbol_exists (drand48 stdlib.h HAVE_DRAND48)
+check_symbol_exists (srand48 stdlib.h HAVE_SRAND48)
+check_symbol_exists (memalign malloc.h HAVE_MEMALIGN)
+check_symbol_exists (posix_memalign stdlib.h HAVE_POSIX_MEMALIGN)
+check_symbol_exists (mach_absolute_time mach/mach_time.h HAVE_MACH_ABSOLUTE_TIME)
+check_symbol_exists (alloca alloca.h HAVE_ALLOCA)
+check_symbol_exists (isnan math.h HAVE_ISNAN)
+check_symbol_exists (snprintf stdio.h HAVE_SNPRINTF)
+
+if (UNIX)
+  set (CMAKE_REQUIRED_LIBRARIES m)
+endif ()
+check_symbol_exists (cosl math.h HAVE_COSL)
+check_symbol_exists (sinl math.h HAVE_SINL)
+
+include (CheckTypeSize)
+check_type_size ("float" SIZEOF_FLOAT)
+check_type_size ("double" SIZEOF_DOUBLE)
+check_type_size ("int" SIZEOF_INT)
+check_type_size ("long" SIZEOF_LONG)
+check_type_size ("long long" SIZEOF_LONG_LONG)
+check_type_size ("unsigned int" SIZEOF_UNSIGNED_INT)
+check_type_size ("unsigned long" SIZEOF_UNSIGNED_LONG)
+check_type_size ("unsigned long long" SIZEOF_UNSIGNED_LONG_LONG)
+check_type_size ("size_t" SIZEOF_SIZE_T)
+check_type_size ("ptrdiff_t" SIZEOF_PTRDIFF_T)
+
+if (UNIX)
+  set (HAVE_LIBM TRUE)
+endif ()
+
+
+if (ENABLE_THREADS)
+  find_package (Threads)
+endif ()
+if (Threads_FOUND)
+  if(CMAKE_USE_PTHREADS_INIT)
+    set (USING_POSIX_THREADS 1)
+  endif ()
+  set (HAVE_THREADS TRUE)
+endif ()
+
+if (ENABLE_OPENMP)
+  find_package (OpenMP)
+endif ()
+if (OPENMP_FOUND)
+  set (HAVE_OPENMP TRUE)
+endif ()
+
+include (CheckCCompilerFlag)
+
+if (ENABLE_SSE)
+  foreach (FLAG "-msse" "/arch:SSE")
+    unset (HAVE_SSE CACHE)
+    check_c_compiler_flag (${FLAG} HAVE_SSE)
+    if (HAVE_SSE)
+      set (SSE_FLAG ${FLAG})
+      break()
+    endif ()
+  endforeach ()
+endif ()
+
+if (ENABLE_SSE2)
+  foreach (FLAG "-msse2" "/arch:SSE2")
+    unset (HAVE_SSE2 CACHE)
+    check_c_compiler_flag (${FLAG} HAVE_SSE2)
+    if (HAVE_SSE2)
+      set (SSE2_FLAG ${FLAG})
+      break()
+    endif ()
+  endforeach ()
+endif ()
+
+if (ENABLE_AVX)
+  foreach (FLAG "-mavx" "/arch:AVX")
+    unset (HAVE_AVX CACHE)
+    check_c_compiler_flag (${FLAG} HAVE_AVX)
+    if (HAVE_AVX)
+      set (AVX_FLAG ${FLAG})
+      break()
+    endif ()
+  endforeach ()
+endif ()
+
+if (ENABLE_AVX2)
+  foreach (FLAG "-mavx2" "/arch:AVX2")
+    unset (HAVE_AVX2 CACHE)
+    check_c_compiler_flag (${FLAG} HAVE_AVX2)
+    if (HAVE_AVX2)
+      set (AVX2_FLAG ${FLAG})
+      break()
+    endif ()
+  endforeach ()
+endif ()
+
+if (HAVE_SSE2 OR HAVE_AVX)
+  set (HAVE_SIMD TRUE)
+endif ()
+file(GLOB           fftw_api_SOURCE                 api/*.c             api/*.h)
+file(GLOB           fftw_dft_SOURCE                 dft/*.c             dft/*.h)
+file(GLOB           fftw_dft_scalar_SOURCE          dft/scalar/*.c      dft/scalar/*.h)
+file(GLOB           fftw_dft_scalar_codelets_SOURCE dft/scalar/codelets/*.c     dft/scalar/codelets/*.h)
+file(GLOB           fftw_dft_simd_SOURCE            dft/simd/*.c        dft/simd/*.h)
+
+file(GLOB           fftw_dft_simd_sse2_SOURCE       dft/simd/sse2/*.c   dft/simd/sse2/*.h)
+file(GLOB           fftw_dft_simd_avx_SOURCE        dft/simd/avx/*.c    dft/simd/avx/*.h)
+file(GLOB           fftw_dft_simd_avx2_SOURCE       dft/simd/avx2/*.c   dft/simd/avx2/*.h)
+file(GLOB           fftw_kernel_SOURCE              kernel/*.c          kernel/*.h)
+file(GLOB           fftw_rdft_SOURCE                rdft/*.c            rdft/*.h)
+file(GLOB           fftw_rdft_scalar_SOURCE         rdft/scalar/*.c     rdft/scalar/*.h)
+
+file(GLOB           fftw_rdft_scalar_r2cb_SOURCE    rdft/scalar/r2cb/*.c
+                                                    rdft/scalar/r2cb/*.h)
+file(GLOB           fftw_rdft_scalar_r2cf_SOURCE    rdft/scalar/r2cf/*.c
+                                                    rdft/scalar/r2cf/*.h)
+file(GLOB           fftw_rdft_scalar_r2r_SOURCE     rdft/scalar/r2r/*.c
+                                                    rdft/scalar/r2r/*.h)
+
+file(GLOB           fftw_rdft_simd_SOURCE           rdft/simd/*.c       rdft/simd/*.h)
+file(GLOB           fftw_rdft_simd_sse2_SOURCE      rdft/simd/sse2/*.c  rdft/simd/sse2/*.h)
+file(GLOB           fftw_rdft_simd_avx_SOURCE       rdft/simd/avx/*.c   rdft/simd/avx/*.h)
+file(GLOB           fftw_rdft_simd_avx2_SOURCE      rdft/simd/avx2/*.c   rdft/simd/avx2/*.h)
+
+file(GLOB           fftw_reodft_SOURCE              reodft/*.c          reodft/*.h)
+file(GLOB           fftw_simd_support_SOURCE        simd-support/*.c    simd-support/*.h)
+file(GLOB           fftw_libbench2_SOURCE           libbench2/*.c       libbench2/*.h)
+list (REMOVE_ITEM   fftw_libbench2_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/libbench2/useropt.c)
+
+set(SOURCEFILES
+    ${fftw_api_SOURCE}
+    ${fftw_dft_SOURCE}
+    ${fftw_dft_scalar_SOURCE}
+    ${fftw_dft_scalar_codelets_SOURCE}
+    ${fftw_dft_simd_SOURCE}
+    ${fftw_kernel_SOURCE}
+    ${fftw_rdft_SOURCE}
+    ${fftw_rdft_scalar_SOURCE}
+
+    ${fftw_rdft_scalar_r2cb_SOURCE}
+    ${fftw_rdft_scalar_r2cf_SOURCE}
+    ${fftw_rdft_scalar_r2r_SOURCE}
+
+    ${fftw_rdft_simd_SOURCE}
+    ${fftw_reodft_SOURCE}
+    ${fftw_simd_support_SOURCE}
+    ${fftw_threads_SOURCE}
+)
+
+set(fftw_par_SOURCE
+    threads/api.c
+    threads/conf.c
+    threads/ct.c
+    threads/dft-vrank-geq1.c
+    threads/f77api.c
+    threads/hc2hc.c
+    threads/rdft-vrank-geq1.c
+    threads/vrank-geq1-rdft2.c)
+
+set (fftw_threads_SOURCE ${fftw_par_SOURCE} threads/threads.c)
+set (fftw_omp_SOURCE ${fftw_par_SOURCE} threads/openmp.c)
+
+
+include_directories(
+    kernel
+    api
+    dft
+    dft/scalar
+    dft/scalar/codelets # really needed?
+    dft/simd
+    dft/simd/sse2
+    dft/simd/avx
+    rdft
+    rdft/scalar
+    rdft/simd
+    reodft
+    simd-support
+    libbench2
+)
+
+install (FILES api/fftw3.h api/fftw3.f DESTINATION include)
+
+
+
+if (WITH_COMBINED_THREADS)
+  list (APPEND SOURCEFILES ${fftw_threads_SOURCE})
+endif ()
+
+
+if (HAVE_SSE2)
+  list (APPEND SOURCEFILES ${fftw_dft_simd_sse2_SOURCE} ${fftw_rdft_simd_sse2_SOURCE})
+endif ()
+
+if (HAVE_AVX)
+  list (APPEND SOURCEFILES ${fftw_dft_simd_avx_SOURCE} ${fftw_rdft_simd_avx_SOURCE})
+endif ()
+
+if (HAVE_AVX2)
+  list (APPEND SOURCEFILES ${fftw_dft_simd_avx2_SOURCE} ${fftw_rdft_simd_avx2_SOURCE})
+endif ()
+
+set (FFTW_VERSION 3.3.6)
+
+set (fftw3_lib fftw3)
+if (ENABLE_FLOAT)
+  set (FFTW_SINGLE TRUE)
+  set (BENCHFFT_SINGLE TRUE)
+  set (fftw3_lib fftw3f)
+endif ()
+
+if (ENABLE_LONG_DOUBLE)
+  set (FFTW_LDOUBLE TRUE)
+  set (BENCHFFT_LDOUBLE TRUE)
+  set(fftw3_lib fftw3l)
+endif ()
+
+if (ENABLE_QUAD_PRECISION)
+  set (FFTW_QUAD TRUE)
+  set (BENCHFFT_QUAD TRUE)
+  set (fftw3_lib fftw3q)
+endif ()
+
+configure_file (cmake.config.h.in config.h @ONLY)
+include_directories (${CMAKE_CURRENT_BINARY_DIR})
+
+if (BUILD_SHARED_LIBS)
+  add_definitions (-DFFTW_DLL)
+endif ()
+
+
+add_library (${fftw3_lib} ${SOURCEFILES})
+if (MSVC)
+  target_compile_definitions (${fftw3_lib} PRIVATE /bigobj)
+endif ()
+if (HAVE_SSE)
+  target_compile_options (${fftw3_lib} PRIVATE ${SSE_FLAG})
+endif ()
+if (HAVE_SSE2)
+  target_compile_options (${fftw3_lib} PRIVATE ${SSE2_FLAG})
+endif ()
+if (HAVE_AVX)
+  target_compile_options (${fftw3_lib} PRIVATE ${AVX_FLAG})
+endif ()
+if (HAVE_AVX2)
+  target_compile_options (${fftw3_lib} PRIVATE ${AVX_FLAG2})
+endif ()
+if (HAVE_LIBM)
+  target_link_libraries (${fftw3_lib} m)
+endif ()
+
+set (subtargets ${fftw3_lib})
+
+if (Threads_FOUND)
+  if (WITH_COMBINED_THREADS)
+    target_link_libraries (${fftw3_lib} ${CMAKE_THREAD_LIBS_INIT})
+  else ()
+    add_library (${fftw3_lib}_threads ${fftw_threads_SOURCE})
+    target_link_libraries (${fftw3_lib}_threads ${fftw3_lib})
+    target_link_libraries (${fftw3_lib}_threads ${CMAKE_THREAD_LIBS_INIT})
+    list (APPEND subtargets ${fftw3_lib}_threads)
+  endif ()
+endif ()
+
+if (OPENMP_FOUND)
+  add_library (${fftw3_lib}_omp ${fftw_omp_SOURCE})
+  target_link_libraries (${fftw3_lib}_omp ${fftw3_lib})
+  target_link_libraries (${fftw3_lib}_omp ${CMAKE_THREAD_LIBS_INIT})
+  list (APPEND subtargets ${fftw3_lib}_omp)
+  target_compile_options (${fftw3_lib}_omp PRIVATE ${OpenMP_C_FLAGS})
+endif ()
+
+foreach(subtarget ${subtargets})
+  set_target_properties (${subtarget} PROPERTIES SOVERSION 3.5.6 VERSION 3)
+  install (TARGETS ${subtarget}
+          RUNTIME DESTINATION bin
+          LIBRARY DESTINATION ${LIBRARY_PATH}
+          ARCHIVE DESTINATION ${LIBRARY_PATH})
+endforeach ()
+
+enable_testing ()
+
+if (Threads_FOUND AND BUILD_TESTS)
+  add_executable (bench ${fftw_libbench2_SOURCE} tests/bench.c tests/hook.c tests/fftw-bench.c)
+
+  if (WITH_COMBINED_THREADS)
+    target_link_libraries (bench ${fftw3_lib})
+  else ()
+    target_link_libraries (bench ${fftw3_lib}_threads)
+  endif ()
+
+  macro (fftw_add_test problem)
+    add_test (NAME ${problem} COMMAND bench -s ${problem})
+  endmacro ()
+
+  fftw_add_test (32x64)
+  fftw_add_test (ib256)
+
+endif ()

--- a/Makefile.am
+++ b/Makefile.am
@@ -41,7 +41,7 @@ endif
 
 SUBDIRS=support $(GENFFT) kernel simd-support dft rdft reodft api	\
 libbench2 $(CHICKEN_EGG) tests mpi $(DOCDIR) tools m4
-EXTRA_DIST=COPYRIGHT bootstrap.sh CONVENTIONS fftw.pc.in
+EXTRA_DIST=COPYRIGHT bootstrap.sh CONVENTIONS fftw.pc.in CMakeLists.txt cmake.config.h.in
 
 SIMD_LIBS =						\
 	simd-support/libsimd_support.la			\

--- a/cmake.config.h.in
+++ b/cmake.config.h.in
@@ -1,0 +1,410 @@
+
+/* Define to compile in long-double precision. */
+#cmakedefine BENCHFFT_LDOUBLE 1
+
+/* Define to compile in quad precision. */
+#cmakedefine BENCHFFT_QUAD 1
+
+/* Define to compile in single precision. */
+#cmakedefine BENCHFFT_SINGLE 1
+
+/* Define to 1 if using `alloca.c'. */
+/* #undef C_ALLOCA */
+
+/* Define to disable Fortran wrappers. */
+/* #undef DISABLE_FORTRAN */
+
+/* Define to dummy `main' function (if any) required to link to the Fortran
+   libraries. */
+/* #undef F77_DUMMY_MAIN */
+
+/* Define to a macro mangling the given C identifier (in lower and upper
+   case), which must not contain underscores, for linking with Fortran. */
+#define F77_FUNC(name,NAME) name ## _
+
+/* As F77_FUNC, but for C identifiers containing underscores. */
+#define F77_FUNC_(name,NAME) name ## _
+
+/* Define if F77_FUNC and F77_FUNC_ are equivalent. */
+#define F77_FUNC_EQUIV 1
+
+/* Define if F77 and FC dummy `main' functions are identical. */
+/* #undef FC_DUMMY_MAIN_EQ_F77 */
+
+/* C compiler name and flags */
+#define FFTW_CC "@CMAKE_C_COMPILER@"
+
+/* Define to enable extra FFTW debugging code. */
+/* #undef FFTW_DEBUG */
+
+/* Define to enable alignment debugging hacks. */
+/* #undef FFTW_DEBUG_ALIGNMENT */
+
+/* Define to enable debugging malloc. */
+/* #undef FFTW_DEBUG_MALLOC */
+
+/* Define to enable the use of alloca(). */
+#define FFTW_ENABLE_ALLOCA 1
+
+/* Define to compile in long-double precision. */
+#cmakedefine FFTW_LDOUBLE 1
+
+/* Define to compile in quad precision. */
+#cmakedefine FFTW_QUAD 1
+
+/* Define to enable pseudorandom estimate planning for debugging. */
+/* #undef FFTW_RANDOM_ESTIMATOR */
+
+/* Define to compile in single precision. */
+#cmakedefine FFTW_SINGLE 1
+
+/* Define to 1 if you have the `abort' function. */
+#define HAVE_ABORT 1
+
+/* Define to 1 if you have `alloca', as a function or macro. */
+#cmakedefine HAVE_ALLOCA 1
+
+/* Define to 1 if you have <alloca.h> and it should be used (not on Ultrix).
+   */
+#cmakedefine HAVE_ALLOCA_H 1
+
+/* Define to enable Altivec optimizations. */
+/* #undef HAVE_ALTIVEC */
+
+/* Define to 1 if you have the <altivec.h> header file. */
+#cmakedefine HAVE_ALTIVEC_H 1
+
+/* Define if you have enabled the cycle counter on ARMv8 */
+/* #undef HAVE_ARMV8CC */
+
+/* Define to enable AVX optimizations. */
+#cmakedefine HAVE_AVX 1
+
+/* Define to enable AVX2 optimizations. */
+#cmakedefine HAVE_AVX2 1
+
+/* Define to enable AVX512 optimizations. */
+/* #undef HAVE_AVX512 */
+
+/* Define to enable 128-bit FMA AVX optimization */
+/* #undef HAVE_AVX_128_FMA */
+
+/* Define to 1 if you have the `BSDgettimeofday' function. */
+/* #undef HAVE_BSDGETTIMEOFDAY */
+
+/* Define to 1 if you have the `clock_gettime' function. */
+#cmakedefine HAVE_CLOCK_GETTIME
+
+/* Define to 1 if you have the `cosl' function. */
+#cmakedefine HAVE_COSL 1
+
+/* Define to 1 if you have the <c_asm.h> header file. */
+#cmakedefine HAVE_C_ASM_H 1
+
+/* Define to 1 if you have the declaration of `cosl', and to 0 if you don't.
+   */
+#cmakedefine01 HAVE_DECL_COSL
+
+/* Define to 1 if you have the declaration of `cosq', and to 0 if you don't.
+   */
+#cmakedefine01 HAVE_DECL_COSQ
+
+/* Define to 1 if you have the declaration of `drand48', and to 0 if you
+   don't. */
+#cmakedefine01 HAVE_DECL_DRAND48
+
+/* Define to 1 if you have the declaration of `memalign', and to 0 if you
+   don't. */
+#cmakedefine01 HAVE_DECL_MEMALIGN
+
+/* Define to 1 if you have the declaration of `posix_memalign', and to 0 if
+   you don't. */
+#cmakedefine01 HAVE_DECL_POSIX_MEMALIGN
+
+/* Define to 1 if you have the declaration of `sinl', and to 0 if you don't.
+   */
+#cmakedefine01 HAVE_DECL_SINL
+
+/* Define to 1 if you have the declaration of `sinq', and to 0 if you don't.
+   */
+#cmakedefine01 HAVE_DECL_SINQ
+
+/* Define to 1 if you have the declaration of `srand48', and to 0 if you
+   don't. */
+#cmakedefine01 HAVE_DECL_SRAND48
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#cmakedefine HAVE_DLFCN_H 1
+
+/* Define to 1 if you don't have `vprintf' but do have `_doprnt.' */
+/* #undef HAVE_DOPRNT */
+
+/* Define to 1 if you have the `drand48' function. */
+#cmakedefine HAVE_DRAND48 1
+
+/* Define if you have a machine with fused multiply-add */
+/* #undef HAVE_FMA */
+
+/* Define to enable generic (gcc) 128-bit SIMD optimizations. */
+/* #undef HAVE_GENERIC_SIMD128 */
+
+/* Define to enable generic (gcc) 256-bit SIMD optimizations. */
+/* #undef HAVE_GENERIC_SIMD256 */
+
+/* Define to 1 if you have the `gethrtime' function. */
+/* #undef HAVE_GETHRTIME */
+
+/* Define to 1 if you have the `gettimeofday' function. */
+#cmakedefine HAVE_GETTIMEOFDAY 1
+
+/* Define to 1 if hrtime_t is defined in <sys/time.h> */
+/* #undef HAVE_HRTIME_T */
+
+/* Define to 1 if you have the <intrinsics.h> header file. */
+#cmakedefine HAVE_INTRINSICS_H 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#cmakedefine HAVE_INTTYPES_H 1
+
+/* Define if the isnan() function/macro is available. */
+#cmakedefine HAVE_ISNAN 1
+
+/* Define to enable KCVI optimizations. */
+/* #undef HAVE_KCVI */
+
+/* Define to 1 if you have the <libintl.h> header file. */
+#cmakedefine HAVE_LIBINTL_H 1
+
+/* Define to 1 if you have the `m' library (-lm). */
+#cmakedefine HAVE_LIBM 1
+
+/* Define to 1 if you have the `quadmath' library (-lquadmath). */
+/* #undef HAVE_LIBQUADMATH */
+
+/* Define to 1 if you have the <limits.h> header file. */
+#cmakedefine HAVE_LIMITS_H 1
+
+/* Define to 1 if the compiler supports `long double' */
+#define HAVE_LONG_DOUBLE 1
+
+/* Define to 1 if you have the `mach_absolute_time' function. */
+#cmakedefine HAVE_MACH_ABSOLUTE_TIME 1
+
+/* Define to 1 if you have the <mach/mach_time.h> header file. */
+#cmakedefine HAVE_MACH_MACH_TIME_H 1
+
+/* Define to 1 if you have the <malloc.h> header file. */
+#cmakedefine HAVE_MALLOC_H 1
+
+/* Define to 1 if you have the `memalign' function. */
+#cmakedefine HAVE_MEMALIGN 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#cmakedefine HAVE_MEMORY_H 1
+
+/* Define to 1 if you have the `memset' function. */
+#define HAVE_MEMSET 1
+
+/* Define to enable use of MIPS ZBus cycle-counter. */
+/* #undef HAVE_MIPS_ZBUS_TIMER */
+
+/* Define if you have the MPI library. */
+/* #undef HAVE_MPI */
+
+/* Define to enable ARM NEON optimizations. */
+/* #undef HAVE_NEON */
+
+/* Define if OpenMP is enabled */
+#cmakedefine HAVE_OPENMP
+
+/* Define to 1 if you have the `posix_memalign' function. */
+#cmakedefine HAVE_POSIX_MEMALIGN 1
+
+/* Define if you have POSIX threads libraries and header files. */
+/* #undef HAVE_PTHREAD */
+
+/* Define to 1 if you have the `read_real_time' function. */
+/* #undef HAVE_READ_REAL_TIME */
+
+/* Define to 1 if you have the `sinl' function. */
+#cmakedefine HAVE_SINL 1
+
+/* Define to 1 if you have the `snprintf' function. */
+#cmakedefine HAVE_SNPRINTF 1
+
+/* Define to 1 if you have the `sqrt' function. */
+#define HAVE_SQRT 1
+
+/* Define to enable SSE/SSE2 optimizations. */
+#cmakedefine01 HAVE_SSE2
+
+/* Define to 1 if you have the <stddef.h> header file. */
+#cmakedefine HAVE_STDDEF_H 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#cmakedefine HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#cmakedefine HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#cmakedefine HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#cmakedefine HAVE_STRING_H 1
+
+/* Define to 1 if you have the `sysctl' function. */
+#define HAVE_SYSCTL 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#cmakedefine HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/sysctl.h> header file. */
+#cmakedefine HAVE_SYS_SYSCTL_H 1
+
+/* Define to 1 if you have the <sys/time.h> header file. */
+#cmakedefine HAVE_SYS_TIME_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#cmakedefine HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the `tanl' function. */
+/* #undef HAVE_TANL */
+
+/* Define if we have a threads library. */
+#cmakedefine HAVE_THREADS 1
+
+/* Define to 1 if you have the `time_base_to_time' function. */
+/* #undef HAVE_TIME_BASE_TO_TIME */
+
+/* Define to 1 if the system has the type `uintptr_t'. */
+#define HAVE_UINTPTR_T 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#cmakedefine HAVE_UNISTD_H 1
+
+/* Define to 1 if you have the `vprintf' function. */
+#define HAVE_VPRINTF 1
+
+/* Define to enable IBM VSX optimizations. */
+/* #undef HAVE_VSX */
+
+/* Define if you have the UNICOS _rtc() intrinsic. */
+/* #undef HAVE__RTC */
+
+/* Define to the sub-directory in which libtool stores uninstalled libraries.
+   */
+#define LT_OBJDIR ".libs/"
+
+/* Define to 1 if your C compiler doesn't accept -c and -o together. */
+/* #undef NO_MINUS_C_MINUS_O */
+
+/* Name of package */
+#define PACKAGE "fftw"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "fftw@fftw.org"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "fftw"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "fftw @FFTW_VERSION@"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "fftw"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "@FFTW_VERSION@"
+
+/* Define to necessary symbol if this constant uses a non-standard name on
+   your system. */
+/* #undef PTHREAD_CREATE_JOINABLE */
+
+/* The size of `double', as computed by sizeof. */
+#define SIZEOF_DOUBLE @SIZEOF_DOUBLE@
+
+/* The size of `fftw_r2r_kind', as computed by sizeof. */
+#define SIZEOF_FFTW_R2R_KIND 4
+
+/* The size of `float', as computed by sizeof. */
+#define SIZEOF_FLOAT @SIZEOF_FLOAT@
+
+/* The size of `int', as computed by sizeof. */
+#define SIZEOF_INT @SIZEOF_INT@
+
+/* The size of `long', as computed by sizeof. */
+#define SIZEOF_LONG @SIZEOF_LONG@
+
+/* The size of `long long', as computed by sizeof. */
+#define SIZEOF_LONG_LONG @SIZEOF_LONG_LONG@
+
+/* The size of `MPI_Fint', as computed by sizeof. */
+/* #undef SIZEOF_MPI_FINT */
+
+/* The size of `ptrdiff_t', as computed by sizeof. */
+#define SIZEOF_PTRDIFF_T @SIZEOF_PTRDIFF_T@
+
+/* The size of `size_t', as computed by sizeof. */
+#define SIZEOF_SIZE_T @SIZEOF_SIZE_T@
+
+/* The size of `unsigned int', as computed by sizeof. */
+#define SIZEOF_UNSIGNED_INT @SIZEOF_UNSIGNED_INT@
+
+/* The size of `unsigned long', as computed by sizeof. */
+#define SIZEOF_UNSIGNED_LONG @SIZEOF_UNSIGNED_LONG@
+
+/* The size of `unsigned long long', as computed by sizeof. */
+#define SIZEOF_UNSIGNED_LONG_LONG @SIZEOF_UNSIGNED_LONG_LONG@
+
+/* The size of `void *', as computed by sizeof. */
+#define SIZEOF_VOID_P @CMAKE_SIZEOF_VOID_P@
+
+/* If using the C implementation of alloca, define if you know the
+   direction of stack growth for your system; otherwise it will be
+   automatically deduced at runtime.
+	STACK_DIRECTION > 0 => grows toward higher addresses
+	STACK_DIRECTION < 0 => grows toward lower addresses
+	STACK_DIRECTION = 0 => direction of growth unknown */
+/* #undef STACK_DIRECTION */
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+
+/* Define to 1 if you can safely include both <sys/time.h> and <time.h>. */
+#cmakedefine TIME_WITH_SYS_TIME 1
+
+/* Define if we have and are using POSIX threads. */
+#cmakedefine USING_POSIX_THREADS 1
+
+/* Version number of package */
+#define VERSION "@FFTW_VERSION@"
+
+/* Use common Windows Fortran mangling styles for the Fortran interfaces. */
+/* #undef WINDOWS_F77_MANGLING */
+
+/* Include g77-compatible wrappers in addition to any other Fortran wrappers.
+   */
+#cmakedefine WITH_G77_WRAPPERS 1
+
+/* Use our own aligned malloc routine; mainly helpful for Windows systems
+   lacking aligned allocation system-library routines. */
+/* #undef WITH_OUR_MALLOC */
+
+/* Use low-precision timers, making planner very slow */
+/* #undef WITH_SLOW_TIMER */
+
+/* Define to empty if `const' does not conform to ANSI C. */
+/* #undef const */
+
+/* Define to `__inline__' or `__inline' if that's what the C compiler
+   calls it, or to nothing if 'inline' is not supported under any name.  */
+#ifndef __cplusplus
+/* #undef inline */
+#endif
+
+/* Define to `unsigned int' if <sys/types.h> does not define. */
+/* #undef size_t */


### PR DESCRIPTION
Addresses #80: allow USERS to build fftw (not the developer side).

Supports static/shared, openmp, threads, various precision options, sse/avx.
Does not support fortran headers, mpi, other processor arches. Maybe that can added in the future. I think it's reasonably complete for now.

Tested here on linux, osx, msvc: https://github.com/xantares/fftw-cmake

cc @EikeVerdenhalven @junghans 