### PR TITLE
Ignore warnings for GNU make extensions.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -12,10 +12,8 @@
 
 touch ChangeLog
 
-echo "PLEASE IGNORE WARNINGS AND ERRORS"
-
 rm -rf autom4te.cache
-autoreconf --verbose --install --symlink --force
+autoreconf --verbose --install --symlink --force -Wno-portability
 
 rm -f config.cache
 


### PR DESCRIPTION
This removes the warnings of the kind

   warning: '%'-style pattern rules are a GNU make extension

which are relied upon by the build system. These are not a problem per se, but tend to swamp the output and may hide true errors.