### PR TITLE
Pr  armv7 pmccntr counter and docs

### DIFF
--- a/README-perfcnt.md
+++ b/README-perfcnt.md
@@ -1,0 +1,93 @@
+Performance Counters
+====================
+
+FFTW measures execution time in the planning stage, optionally taking advantage
+of hardware performance counters. This document describes the supported
+counters and additional steps needed to enable each on different architectures.
+
+See `./configure --help` for flags for enabling each supported counter.
+See [kernel/cycle.h](kernel/cycle.h) for the code that accesses the counters.
+
+ARMv7-A (armv7a)
+================
+
+`CNTVCT`: Virtual Count Register in VMSA
+--------------------------------------
+
+A 64-bit counter part of Virtual Memory System Architecture.
+Section B4.1.34 in ARM Architecture Reference Manual ARMv7-A/ARMv7-R
+
+For access from user mode, requires `CNTKCTL.PL0VCTEN == 1`, which must
+be set in kernel mode on each CPU:
+
+        #define CNTKCTL_PL0VCTEN 0x2 /* B4.1.26 in ARM Architecture Rreference */
+        uint32_t r;
+        asm volatile("mrc p15, 0, %0, c14, c1, 0" : "=r"(r)); /* read */
+        r |= CNTKCTL_PL0VCTEN;
+        asm volatile("mcr p15, 0, %0, c14, c1, 0" :: "r"(r)); /* write */
+
+Kernel module source *which can be patched with the above code* available at:
+https://github.com/thoughtpolice/enable_arm_pmu
+
+`PMCCNTR`: Performance Monitors Cycle Count Register in VMSA
+----------------------------------------------------------
+
+A 32-bit counter part of Virtual Memory System Architecture.
+Section B4.1.113 in ARM Architecture Reference Manual ARMv7-A/ARMv7-R
+
+For access from user mode, requires user-mode access to PMU to be enabled
+(`PMUSERENR.EN == 1`), which must be done from kernel mode on each CPU:
+
+        #define PERF_DEF_OPTS (1 | 16)
+        /* enable user-mode access to counters */
+        asm volatile("mcr p15, 0, %0, c9, c14, 0" :: "r"(1));
+        /* Program PMU and enable all counters */
+        asm volatile("mcr p15, 0, %0, c9, c12, 0" :: "r"(PERF_DEF_OPTS));
+        asm volatile("mcr p15, 0, %0, c9, c12, 1" :: "r"(0x8000000f));
+
+Kernel module source with the above code available at:
+[GitHub thoughtpolice/enable\_arm\_pmu](https://github.com/thoughtpolice/enable_arm_pmu)
+
+More information:
+http://neocontra.blogspot.com/2013/05/user-mode-performance-counters-for.html
+
+ARMv8-A (aarch64)
+=================
+
+`CNTVCT_EL0`: Counter-timer Virtual Count Register
+------------------------------------------------
+
+A 64-bit counter, part of Generic Registers.
+Section D8.5.17 in ARM Architecture Reference Manual ARMv8-A
+
+For user-mode access, requires `CNTKCTL_EL1.EL0VCTEN == 1`, which
+must be set from kernel mode for each CPU:
+
+        #define CNTKCTL_EL0VCTEN 0x2
+        uint32_t r;
+        asm volatile("mrs %0, CNTKCTL_EL1" : "=r"(r)); /* read */
+        r |= CNTKCTL_EL0VCTEN;
+        asm volatile("msr CNTKCTL_EL1, %0" :: "r"(r)); /* write */
+
+*WARNING*: Above code was not tested.
+
+`PMCCNTR_EL0`: Performance Monitors Cycle Count Register
+------------------------------------------------------
+
+A 64-bit counter, part of Performance Monitors.
+Section D8.4.2 in ARM Architecture Reference Manual ARMv8-A
+
+For access from user mode, requires user-mode access to PMU (`PMUSERENR_EL0.EN
+== 1`), which must be set from kernel mode for each CPU:
+
+        #define PERF_DEF_OPTS (1 | 16)
+        /* enable user-mode access to counters */
+        asm volatile("msr PMUSERENR_EL0, %0" :: "r"(1));
+        /* Program PMU and enable all counters */
+        asm volatile("msr PMCR_EL0, %0" :: "r"(PERF_DEF_OPTS));
+        asm volatile("msr PMCNTENSET_EL0, %0" :: "r"(0x8000000f));
+        asm volatile("msr PMCCFILTR_EL0, %0" :: "r"(0));
+
+Kernel module source with the above code available at:
+[GitHub rdolbeau/enable\_arm\_pmu](https://github.com/rdolbeau/enable_arm_pmu)
+or in [Pull Request #2 at thoughtpolice/enable\_arm\_pmu](https://github.com/thoughtpolice/enable_arm_pmu/pull/2)

--- a/configure.ac
+++ b/configure.ac
@@ -200,19 +200,24 @@ if test "$have_neon" = "yes"; then
 fi
 AM_CONDITIONAL(HAVE_NEON, test "$have_neon" = "yes")
 
-AC_ARG_ENABLE(armv8cyclecounter, [AC_HELP_STRING([--enable-armv8cyclecounter],[enable the cycle counter on ARMv8 via the PMCCNTR_EL0 register. Requires enabling in kernel mode, see <https://github.com/rdolbeau/enable_arm_pmu>])], have_armv8cyclecounter=$enableval)
+AC_ARG_ENABLE(armv8cyclecounter, [AC_HELP_STRING([--enable-armv8cyclecounter],[enable the cycle counter on ARMv8 via the PMCCNTR_EL0 register (see README-perfcounters for details and mandatory instructions)])], have_armv8cyclecounter=$enableval)
 if test "$have_armv8cyclecounter"x = "yes"x; then
 	AC_DEFINE(HAVE_ARMV8CC,1,[Define if you have enabled the cycle counter on ARMv8])
 fi
 
-AC_ARG_ENABLE(armv8-cntvct-el0, [AC_HELP_STRING([--enable-armv8-cntvct-el0],[enable the cycle counter on ARMv8 via the CNTVCT_EL0 register])], have_armv8cntvctel0=$enableval)
+AC_ARG_ENABLE(armv8-cntvct-el0, [AC_HELP_STRING([--enable-armv8-cntvct-el0],[enable the cycle counter on ARMv8 via the CNTVCT_EL0 register (see README-perfcounters for details and mandatory instructions)])], have_armv8cntvctel0=$enableval)
 if test "$have_armv8cntvctel0"x = "yes"x; then
 	AC_DEFINE(HAVE_ARMV8_CNTVCT_EL0,1,[Define if you have enabled the CNTVCT_EL0 cycle counter on ARMv8])
 fi
 
-AC_ARG_ENABLE(armv7a-cntvct, [AC_HELP_STRING([--enable-armv7a-cntvct],[enable the cycle counter on Armv7a via the CNTVCT register])], have_armv7acntvct=$enableval)
+AC_ARG_ENABLE(armv7a-cntvct, [AC_HELP_STRING([--enable-armv7a-cntvct],[enable the cycle counter on Armv7a via the CNTVCT register (see README-perfcounters for details and mandatory instructions)])], have_armv7acntvct=$enableval)
 if test "$have_armv7acntvct"x = "yes"x; then
 	AC_DEFINE(HAVE_ARMV7A_CNTVCT,1,[Define if you have enabled the CNTVCT cycle counter on ARMv7a])
+fi
+
+AC_ARG_ENABLE(armv7a-pmccntr, [AC_HELP_STRING([--enable-armv7a-pmccntr],[enable the cycle counter on Armv7a via the PMCCNTR register (see README-perfcounters for details and mandatory instructions)])], have_armv7apmccntr=$enableval)
+if test "$have_armv7apmccntr"x = "yes"x; then
+	AC_DEFINE(HAVE_ARMV7A_PMCCNTR,1,[Define if you have enabled the PMCCNTR cycle counter on ARMv7a])
 fi
 
 AC_ARG_ENABLE(generic-simd128, [AC_HELP_STRING([--enable-generic-simd128],[enable generic (gcc) 128-bit SIMD optimizations])], have_generic_simd128=$enableval, have_generic_simd128=no)

--- a/configure.ac
+++ b/configure.ac
@@ -200,9 +200,9 @@ if test "$have_neon" = "yes"; then
 fi
 AM_CONDITIONAL(HAVE_NEON, test "$have_neon" = "yes")
 
-AC_ARG_ENABLE(armv8cyclecounter, [AC_HELP_STRING([--enable-armv8cyclecounter],[enable the cycle counter on ARMv8 via the PMCCNTR_EL0 register (see README-perfcounters for details and mandatory instructions)])], have_armv8cyclecounter=$enableval)
-if test "$have_armv8cyclecounter"x = "yes"x; then
-	AC_DEFINE(HAVE_ARMV8CC,1,[Define if you have enabled the cycle counter on ARMv8])
+AC_ARG_ENABLE(armv8-pmccntr-el0, [AC_HELP_STRING([--enable-armv8-pmccntr-el0],[enable the cycle counter on ARMv8 via the PMCCNTR_EL0 register (see README-perfcounters for details and mandatory instructions)])], have_armv8pmccntrel0=$enableval)
+if test "$have_armv8pmccntrel0"x = "yes"x; then
+	AC_DEFINE(HAVE_ARMV8_PMCCNTR_EL0,1,[Define if you have enabled the PMCCNTR_EL0 cycle counter on ARMv8])
 fi
 
 AC_ARG_ENABLE(armv8-cntvct-el0, [AC_HELP_STRING([--enable-armv8-cntvct-el0],[enable the cycle counter on ARMv8 via the CNTVCT_EL0 register (see README-perfcounters for details and mandatory instructions)])], have_armv8cntvctel0=$enableval)

--- a/kernel/cycle.h
+++ b/kernel/cycle.h
@@ -527,6 +527,18 @@ INLINE_ELAPSED(inline)
 #define HAVE_TICK_COUNTER
 #endif
 
+#if defined(HAVE_ARMV7A_PMCCNTR)
+typedef uint64_t ticks;
+static inline ticks getticks(void)
+{
+  uint32_t r;
+  asm volatile("mrc p15, 0, %0, c9, c13, 0" : "=r"(r) );
+  return r;
+}
+INLINE_ELAPSED(inline)
+#define HAVE_TICK_COUNTER
+#endif
+
 #if defined(__aarch64__) && defined(HAVE_ARMV8_CNTVCT_EL0) && !defined(HAVE_ARMV8CC)
 typedef uint64_t ticks;
 static inline ticks getticks(void)

--- a/kernel/cycle.h
+++ b/kernel/cycle.h
@@ -539,7 +539,7 @@ INLINE_ELAPSED(inline)
 #define HAVE_TICK_COUNTER
 #endif
 
-#if defined(__aarch64__) && defined(HAVE_ARMV8_CNTVCT_EL0) && !defined(HAVE_ARMV8CC)
+#if defined(__aarch64__) && defined(HAVE_ARMV8_CNTVCT_EL0) && !defined(HAVE_ARMV8_PMCCNTR_EL0)
 typedef uint64_t ticks;
 static inline ticks getticks(void)
 {
@@ -551,7 +551,7 @@ INLINE_ELAPSED(inline)
 #define HAVE_TICK_COUNTER
 #endif
 
-#if defined(__aarch64__) && defined(HAVE_ARMV8CC)
+#if defined(__aarch64__) && defined(HAVE_ARMV8_PMCCNTR_EL0)
 typedef uint64_t ticks;
 static inline ticks getticks(void)
 {


### PR DESCRIPTION

    perf counters: add PMCCNTR for ARMv7 and add docs
    
    The existing armv7 counter (CNTVCT) does need enabling from kernel mode (so
    updated the configure help), and the enable bit is different from the PMU
    enable bit (described in the new docs).
    
    Tested on XU4: printed the returned counter values and they look reasonable.

If CNTVCT is not enabled in kernel mode, using the code in the new docs, I get illegal instruction at the instructions that reads CNTVCT.

FWIW, I PRed: https://github.com/thoughtpolice/enable_arm_pmu/pull/6

While at it also did this rename (easy to drop if can't break compatibility with the old --enable-armv8cc):

    perf counters: name ARMv8 PMCCNTR_EL0 explicitly
    
    For consistency with the rest.

RFC: It might be worth it to add the kernel module source into this repo, because those linked repos and forks are scattered and seem like they are not maintained. Integrating into the build is probably out of the question due to the need for kernel sources, but maybe at least install the module source into /usr/share, and read the config vars corresponding to --enable* to include the right instructions into that source. Thoughts?