### PR TITLE
Fix the incorrect comment about Util.interval

### DIFF
--- a/genfft/util.ml
+++ b/genfft/util.ml
@@ -145,7 +145,7 @@ let info string =
 (* iota n produces the list [0; 1; ...; n - 1] *)
 let iota n = forall [] cons 0 n identity
 
-(* interval a b produces the list [a; 1; ...; b - 1] *)
+(* interval a b produces the list [a; a + 1; ...; b - 1] *)
 let interval a b = List.map ((+) a) (iota (b - a))
 
 (*


### PR DESCRIPTION
I noticed a mistake in the comment about what `Util.interval` produces.

`interval a b` produces the list `[a; a + 1; ...; b - 1]` rather than the stated `[a; 1; ...; b - 1]`.

Thanks!