### PR TITLE
Small performance improvement for avx-512 on Skylake-SP

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -151,6 +151,15 @@ if test "$have_avx512" = "yes"; then
 fi
 AM_CONDITIONAL(HAVE_AVX512, test "$have_avx512" = "yes")
 
+AC_ARG_ENABLE(avx512-scattergather, [AC_HELP_STRING([--enable-avx512-scattergather],[Favor scatter/gather when using AVX512 (for Xeon Phi/KNL)])], have_avx512_scattergather=$enableval, have_avx512_scattergather=no)
+if test "$have_avx512_scattergather" = "yes"; then
+        AC_DEFINE(AVX512_SCATTERGATHER,1,[Define to favor scatter/gather when using AVX512.])
+        if test "$have_avx512" != "yes"; then
+                AC_MSG_ERROR([AVX512 Scatter/Gather requires AVX512])
+        fi
+fi
+AM_CONDITIONAL(AVX512_SCATTERGATHER, test "$have_avx512_scattergather" = "yes")
+
 dnl 128-bit AVX is special. There is no reason to use it on Intel processors
 dnl since SSE2 is just as fast. However, on AMD processors we can both use
 dnl FMA4, and 128-bit SIMD is better than 256-bit since core pairs in a

--- a/simd-support/simd-avx512.h
+++ b/simd-support/simd-avx512.h
@@ -99,31 +99,19 @@ static inline void STA(R *x, V v, INT ovs, const R *aligned_like) {
 static inline V LDu(const R *x, INT ivs, const R *aligned_like)
 {
   (void)aligned_like; /* UNUSED */
-  __m512i index = _mm512_set_epi32(7 * ivs + 1, 7 * ivs,
-                                   6 * ivs + 1, 6 * ivs,
-                                   5 * ivs + 1, 5 * ivs,
-                                   4 * ivs + 1, 4 * ivs,
-                                   3 * ivs + 1, 3 * ivs,
-                                   2 * ivs + 1, 2 * ivs,
-                                   1 * ivs + 1, 1 * ivs,
-                                   0 * ivs + 1, 0 * ivs);
+  /* pretend pair of single are a double */
+  const __m256i index = _mm256_set_epi32(7 * ivs, 6 * ivs, 5 * ivs, 4 * ivs, 3 * ivs, 2 * ivs, 1 * ivs, 0 * ivs);
   
-  return _mm512_i32gather_ps(index, x, 4);
+  return (V)_mm512_i32gather_pd(index, x, 4);
 }
 
 static inline void STu(R *x, V v, INT ovs, const R *aligned_like)
 {
   (void)aligned_like; /* UNUSED */
-  __m512i index = _mm512_set_epi32(7 * ovs + 1, 7 * ovs,
-                                   6 * ovs + 1, 6 * ovs,
-                                   5 * ovs + 1, 5 * ovs,
-                                   4 * ovs + 1, 4 * ovs,
-                                   3 * ovs + 1, 3 * ovs,
-                                   2 * ovs + 1, 2 * ovs,
-                                   1 * ovs + 1, 1 * ovs,
-                                   0 * ovs + 1, 0 * ovs);
-  
-  _mm512_i32scatter_ps(x, index, v, 4);
+  /* pretend pair of single are a double */
+  const __m256i index = _mm256_set_epi32(7 * ovs, 6 * ovs, 5 * ovs, 4 * ovs, 3 * ovs, 2 * ovs, 1 * ovs, 0 * ovs);
+
+  _mm512_i32scatter_pd(x, index, (__m512d)v, 4);
 }
 
 #else /* !FFTW_SINGLE */


### PR DESCRIPTION
This improves performance a bit on the Skylake-SP cores (Xeon Scalable), by replacing gather/scatter by slightly more efficient code: breaking down the instruction in 128 bits chunk for DP, and going for 64-bits scatter/gather (instead of 32) in SP. The original gather/scatter code is still available for DP, as it's probably faster on Knights Landing (KNL, Xeon Phi 72xx). The SP code should be a win on KNL as well.

Tested with make check/bigcheck, and for performance on synthetic code, could probably use some real-life testing for performance.