### PR TITLE
Fixed a deprecated (and removed) Sort module use in genfft

### DIFF
--- a/genfft/annotate.ml
+++ b/genfft/annotate.ml
@@ -78,9 +78,9 @@ let reorder l =
 	  List.map 
 	    (fun (a, x) -> ((a, x), (overlap va x, List.length x))) b in
 	let c' =
-	  Sort.list 
+	  List.sort 
 	    (fun (_, (a, la)) (_, (b, lb)) -> 
-	      la < lb || a > b)
+              if la > lb then la - lb else b - a)
 	    c in
 	let b' = List.map (fun (a, _) -> a) c' in
 	a :: (loop b') in


### PR DESCRIPTION
Dear maintainers,

Ocaml dropped module Sort as of 4.08, which is now shipped in Debian's testing, and is going to be in stable branch in some time. 

I have switched code from using Sort to List.sort( which was suggested in the ocaml manual ), while also reversing the underlying predicate because while Sort.list had to mimic <= operator, List.sort is using '>' for a predicate to sort in increasing order. Consult manuals at:
https://ocaml.org/releases/4.07/htmlman/libref/Sort.html
https://ocaml.org/releases/4.10/htmlman/libref/List.html

The build has been checked with linux subsystem for linux running 'debian/bullseye'. Configured with './configure --enable-maintainer-mode --enable-single --enable-sse --enable-threads'. Both build and 'make check' ran without errors.

Kind regards,
Artem Bondarenko

P.S. I only ever heard of 'ocaml' language for the first time yesterday, if you can please double check.