### PR TITLE
Fix x86 compilation in MSVC

### DIFF
--- a/simd-support/x86-cpuid.h
+++ b/simd-support/x86-cpuid.h
@@ -22,6 +22,7 @@
 /* this code was kindly donated by Eric J. Korpela */
 
 #ifdef _MSC_VER
+#include <intrin.h>
 #ifndef inline
 #define inline __inline
 #endif


### PR DESCRIPTION
`__cpuidex` is defined in `intrin.h`.