### PR TITLE
README.md: link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ code, do not require any special tools or knowledge, and can be
 compiled on any system with a C compiler.
 
 Advanced users and FFTW maintainers may obtain code from github and
-run the generation process themselves.  See README for details.
-
+run the generation process themselves.  See [README](README) for
+details.


### PR DESCRIPTION
[README.md](https://github.com/FFTW/fftw3/blob/master/README.md) refers the user to the text-only [README](https://github.com/FFTW/fftw3/blob/master/README), which contains - among other things, build instructions. Since the two files have a very similar name, this may lead to confusion for first-time users.

With this commit, a relative hyperlink pointing to `README` is added in `README.md`, in order to make it explicit what file is being referenced.