### PR TITLE
First attempt at adding planner_nthreads

### DIFF
--- a/api/fftw3.h
+++ b/api/fftw3.h
@@ -380,6 +380,9 @@ FFTW_EXTERN void                                                        \
 FFTW_CDECL X(plan_with_nthreads)(int nthreads);                         \
                                                                         \
 FFTW_EXTERN int                                                         \
+FFTW_CDECL X(planner_nthreads)(void);                                   \
+                                                                        \
+FFTW_EXTERN int                                                         \
 FFTW_CDECL X(init_threads)(void);                                       \
                                                                         \
 FFTW_EXTERN void                                                        \

--- a/doc/legacy-fortran.texi
+++ b/doc/legacy-fortran.texi
@@ -260,6 +260,15 @@ FFTW}), you would simply prefix these calls with:
 (You might want to check the value of @code{iret}: if it is zero, it
 indicates an unlikely error during thread initialization.)
 
+To check the number of threads currently being used by the planner, you
+can do the following:
+
+@example
+        integer iret
+        call dfftw_planner_nthreads(iret)
+@end example
+@findex dfftw_planner_nthreads
+
 To transform a three-dimensional array in-place with C, you might do:
 
 @example

--- a/doc/threads.texi
+++ b/doc/threads.texi
@@ -119,6 +119,14 @@ before a call to @code{fftw_plan_with_nthreads} are unaffected.  If you
 pass an @code{nthreads} argument of @code{1} (the default), threads are
 disabled for subsequent plans.
 
+You can determine the current number of threads that the planner can
+use by calling:
+
+@example
+int fftw_planner_nthreads(void);
+@end example
+@findex fftw_planner_nthreads
+
 @cindex OpenMP
 With OpenMP, to configure FFTW to use all of the currently running
 OpenMP threads (set by @code{omp_set_num_threads(nthreads)} or by the

--- a/doc/upgrading.texi
+++ b/doc/upgrading.texi
@@ -189,7 +189,8 @@ now stored in the plan, and is specified before the planner is called by
 @code{fftw_plan_with_nthreads}.  The threads initialization routine used
 to be called @code{fftw_threads_init} and would return zero on success;
 the new routine is called @code{fftw_init_threads} and returns zero on
-failure.  @xref{Multi-threaded FFTW}.
+failure. The current number of threads used by the planner can be
+checked with @code{fftw_planner_nthreads}. @xref{Multi-threaded FFTW}.
 
 There is no separate threads header file in FFTW 3; all the function
 prototypes are in @code{<fftw3.h>}.  However, you still have to link to

--- a/tests/fftw-bench.c
+++ b/tests/fftw-bench.c
@@ -125,6 +125,7 @@ void rdwisdom(void)
      if (threads_ok) {
 	  BENCH_ASSERT(FFTW(init_threads)());
 	  FFTW(plan_with_nthreads)(nthreads);
+	  BENCH_ASSERT(FFTW(planner_nthreads)() == nthreads);
           FFTW(make_planner_thread_safe)();
 #ifdef _OPENMP
 	  omp_set_num_threads(nthreads);

--- a/threads/api.c
+++ b/threads/api.c
@@ -80,6 +80,11 @@ void X(plan_with_nthreads)(int nthreads)
      plnr->nthr = X(imax)(1, nthreads);
 }
 
+int X(planner_nthreads)(void)
+{
+    return X(the_planner)()->nthr;
+}
+
 void X(make_planner_thread_safe)(void)
 {
      X(threads_register_planner_hooks)();

--- a/threads/f77funcs.h
+++ b/threads/f77funcs.h
@@ -28,6 +28,11 @@ FFTW_VOIDFUNC F77(plan_with_nthreads, PLAN_WITH_NTHREADS)(int *nthreads)
      X(plan_with_nthreads)(*nthreads);
 }
 
+FFTW_VOIDFUNC F77(planner_nthreads, PLANNER_NTHREADS)(int *nthreads)
+{
+    *nthreads = X(planner_nthreads)();
+}
+
 FFTW_VOIDFUNC F77(init_threads, INIT_THREADS)(int *okay)
 {
      *okay = X(init_threads)();


### PR DESCRIPTION
While you can currently set the maximum number of threads used by the planner,
there is no way to check that number. This simply adds a new function,
`planner_nthreads`, that provides this information, as was suggested by
@stevengj (JuliaMath/FFTW.jl#150).

I have no idea which files I should edit to introduce this new function beyond `threads/api.c`, due to my unfamiliarity with autoconf and the build system used by FFTW. I have additionally added `planner_nthreads` to `api/fftw3.h`, and `threads/f77funcs.h`. I was unsure how to test this new function, and I have not yet done so. I will try to figure that out soon, if someone with more experience does not do it before I can. 

I have also added `planner_nthreads` to all the relevant portions of the documentation that I could find.