### PR TITLE
Better C++ support (#254)

### DIFF
--- a/api/fftw3.h
+++ b/api/fftw3.h
@@ -50,16 +50,22 @@
 #include <stdio.h>
 
 #ifdef __cplusplus
+#  if __cplusplus >= 201103L && defined(FFTW_cpp_complex)
+#    include <complex>
+#    define FFTW_DEFINE_COMPLEX(R, C) typedef ::std::complex<R> C
+#  endif
 extern "C"
 {
 #endif /* __cplusplus */
 
+#ifndef FFTW_DEFINE_COMPLEX
 /* If <complex.h> is included, use the C99 complex type.  Otherwise
    define a type bit-compatible with C99 complex */
-#if !defined(FFTW_NO_Complex) && defined(_Complex_I) && defined(complex) && defined(I)
-#  define FFTW_DEFINE_COMPLEX(R, C) typedef R _Complex C
-#else
-#  define FFTW_DEFINE_COMPLEX(R, C) typedef R C[2]
+#  if !defined(FFTW_NO_Complex) && defined(_Complex_I) && defined(complex) && defined(I)
+#    define FFTW_DEFINE_COMPLEX(R, C) typedef R _Complex C
+#  else
+#    define FFTW_DEFINE_COMPLEX(R, C) typedef R C[2]
+#  endif
 #endif
 
 #define FFTW_CONCAT(prefix, name) prefix ## name


### PR DESCRIPTION
The patch below allows to use fftw3.h with native support for C++ `std::complex`.

Since it is not possible in C++ to detect automatically whether the header `<complex>` has been included this is an **opt in feature**. The **macro `FFTW_cpp_complex`** has to be defined:
``` c++
#define FFTW_cpp_complex
#include "fftw3.h"
```

If this is done in C++ context and the C++ version is at least C++11 then the `fftw*_complex` types are replaced by the class `std::complex<R>`.

Optionally the users may define their own implementation of `FFTW_DEFINE_COMPLEX(R, C)`. This takes precedence over the implementation in fftw3.h. But whether this should be a documented property is questionable since wired things happen if the type is not binary compatible.