### PR TITLE
default to CNTVCT_EL0 cycle counter on Apple M1

### DIFF
--- a/kernel/cycle.h
+++ b/kernel/cycle.h
@@ -52,7 +52,7 @@
    defined according to whether the corresponding function/type/header
    is available on your system.  The necessary macros are most
    conveniently defined if you are using GNU autoconf, via the tests:
-   
+
    dnl ---------------------------------------------------------------------
 
    AC_C_INLINE
@@ -122,7 +122,7 @@ static __inline double elapsed(ticks t1, ticks t0) /* time in nanoseconds */
 {
      time_base_to_time(&t1, TIMEBASE_SZ);
      time_base_to_time(&t0, TIMEBASE_SZ);
-     return (((double)t1.tb_high - (double)t0.tb_high) * 1.0e9 + 
+     return (((double)t1.tb_high - (double)t0.tb_high) * 1.0e9 +
 	     ((double)t1.tb_low - (double)t0.tb_low));
 }
 
@@ -166,7 +166,7 @@ INLINE_ELAPSED(__inline__)
 
 /*----------------------------------------------------------------*/
 /*
- * Pentium cycle counter 
+ * Pentium cycle counter
  */
 #if (defined(__GNUC__) || defined(__ICC)) && defined(__i386__)  && !defined(HAVE_TICK_COUNTER)
 typedef unsigned long long ticks;
@@ -205,9 +205,9 @@ static __inline ticks getticks(void)
 }
 
 static __inline double elapsed(ticks t1, ticks t0)
-{  
+{
      return (double)t1.QuadPart - (double)t0.QuadPart;
-}  
+}
 
 #define HAVE_TICK_COUNTER
 #define TIME_MIN 5000.0   /* unreliable pentium IV cycle counter */
@@ -222,9 +222,9 @@ typedef unsigned long long ticks;
 
 static __inline__ ticks getticks(void)
 {
-     unsigned a, d; 
-     __asm__ __volatile__ ("rdtsc" : "=a" (a), "=d" (d)); 
-     return ((ticks)a) | (((ticks)d) << 32); 
+     unsigned a, d;
+     __asm__ __volatile__ ("rdtsc" : "=a" (a), "=d" (d));
+     return ((ticks)a) | (((ticks)d) << 32);
 }
 
 INLINE_ELAPSED(__inline__)
@@ -236,7 +236,7 @@ INLINE_ELAPSED(__inline__)
 /* PGI compiler, courtesy Cristiano Calonaci, Andrea Tarsi, & Roberto Gori.
    NOTE: this code will fail to link unless you use the -Masmkeyword compiler
    option (grrr). */
-#if defined(__PGI) && defined(__x86_64__) && !defined(HAVE_TICK_COUNTER) 
+#if defined(__PGI) && defined(__x86_64__) && !defined(HAVE_TICK_COUNTER)
 typedef unsigned long long ticks;
 static ticks getticks(void)
 {
@@ -274,9 +274,9 @@ static __inline__ ticks getticks(void)
 {
      return __getReg(_IA64_REG_AR_ITC);
 }
- 
+
 INLINE_ELAPSED(__inline__)
- 
+
 #define HAVE_TICK_COUNTER
 #endif
 
@@ -339,7 +339,7 @@ INLINE_ELAPSED(inline)
 
 /*----------------------------------------------------------------*/
 /*
- * PA-RISC cycle counter 
+ * PA-RISC cycle counter
  */
 #if (defined(__hppa__) || defined(__hppa)) && !defined(HAVE_TICK_COUNTER)
 typedef unsigned long ticks;
@@ -387,7 +387,7 @@ INLINE_ELAPSED(__inline__)
 /*----------------------------------------------------------------*/
 #if defined(__GNUC__) && defined(__alpha__) && !defined(HAVE_TICK_COUNTER)
 /*
- * The 32-bit cycle counter on alpha overflows pretty quickly, 
+ * The 32-bit cycle counter on alpha overflows pretty quickly,
  * unfortunately.  A 1GHz machine overflows in 4 seconds.
  */
 typedef unsigned int ticks;
@@ -539,7 +539,7 @@ INLINE_ELAPSED(inline)
 #define HAVE_TICK_COUNTER
 #endif
 
-#if defined(__aarch64__) && defined(HAVE_ARMV8_CNTVCT_EL0) && !defined(HAVE_ARMV8_PMCCNTR_EL0)
+#if defined(__aarch64__) && (defined(__APPLE__) || defined(HAVE_ARMV8_CNTVCT_EL0)) && !defined(HAVE_ARMV8_PMCCNTR_EL0)
 typedef uint64_t ticks;
 static inline ticks getticks(void)
 {


### PR DESCRIPTION
It seems that `CNTVCT_EL0` support is enabled by default on macOS running on the M1 (aarch64), but *not* `PMCCNTR_EL0`.     It makes sense to me to enable the former by default, as users are unlikely to know about this and not having a cycle counter really degrades FFTW's performance.

cc @matteo-frigo 

PS. Sorry for all of the whitespace changes; my editor is set to automatically delete trailing whitespace in `.c` files.