### PR TITLE
Add RISC-V vector spec v1.0 support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -104,6 +104,17 @@ GENERIC_SIMD256_LIBS = dft/simd/generic-simd256/libdft_generic_simd256_codelets.
 rdft/simd/generic-simd256/librdft_generic_simd256_codelets.la
 endif
 
+if HAVE_RVV
+RVV_LIBS = dft/simd/rvv128/libdft_rvv128_codelets.la      \
+rdft/simd/rvv128/librdft_rvv128_codelets.la	\
+dft/simd/rvv256/libdft_rvv256_codelets.la      \
+rdft/simd/rvv256/librdft_rvv256_codelets.la	\
+dft/simd/rvv512/libdft_rvv512_codelets.la      \
+rdft/simd/rvv512/librdft_rvv512_codelets.la	\
+dft/simd/rvv1024/libdft_rvv1024_codelets.la      \
+rdft/simd/rvv1024/librdft_rvv1024_codelets.la
+endif
+
 if THREADS
 if COMBINED_THREADS
 COMBINED_THREADLIBS=threads/libfftw3@PREC_SUFFIX@_threads.la
@@ -127,7 +138,7 @@ libfftw3@PREC_SUFFIX@_la_LIBADD =			\
         $(SIMD_LIBS) $(SSE2_LIBS) $(AVX_LIBS) $(AVX_128_FMA_LIBS) \
         $(AVX2_LIBS) $(ALTIVEC_LIBS) \
         $(VSX_LIBS) $(NEON_LIBS) $(KCVI_LIBS) $(AVX512_LIBS) \
-        $(GENERIC_SIMD128_LIBS) $(GENERIC_SIMD256_LIBS) \
+        $(GENERIC_SIMD128_LIBS) $(GENERIC_SIMD256_LIBS) $(RVV_LIBS) \
 	$(COMBINED_THREADLIBS)
 
 if QUAD

--- a/api/version.c
+++ b/api/version.c
@@ -85,4 +85,8 @@ const char X(version)[] = PACKAGE "-" PACKAGE_VERSION
    "-generic_simd256"
 #endif
 
+#if defined(HAVE_R5V)
+   "-rvv"
+#endif
+
 ;

--- a/cmake.config.h.in
+++ b/cmake.config.h.in
@@ -202,6 +202,9 @@
 /* Define to enable ARM NEON optimizations. */
 /* #undef HAVE_NEON */
 
+/* Define to enable RISC-V Vector optimizations. */
+/* #undef HAVE_RVV */
+
 /* Define if OpenMP is enabled */
 #cmakedefine HAVE_OPENMP
 

--- a/configure.ac
+++ b/configure.ac
@@ -235,6 +235,12 @@ if test "$have_generic_simd256" = "yes"; then
 fi
 AM_CONDITIONAL(HAVE_GENERIC_SIMD256, test "$have_generic_simd256" = "yes")
 
+AC_ARG_ENABLE(rvv, [AC_HELP_STRING([--enable-rvv],[enable RISC-V V optimizations])], have_rvv=$enableval, have_rvv=no)
+if test "$have_rvv" = "yes"; then
+        AC_DEFINE(HAVE_RVV,1,[Define to enable RISC-V V optimizations.])
+fi
+AM_CONDITIONAL(HAVE_RVV, test "$have_rvv" = "yes")
+
 
 dnl FIXME:
 dnl AC_ARG_ENABLE(mips-ps, [AC_HELP_STRING([--enable-mips-ps],[enable MIPS pair-single optimizations])], have_mips_ps=$enableval, have_mips_ps=no)
@@ -770,6 +776,10 @@ AC_CONFIG_FILES([
    dft/simd/neon/Makefile
    dft/simd/generic-simd128/Makefile
    dft/simd/generic-simd256/Makefile
+   dft/simd/rvv128/Makefile
+   dft/simd/rvv256/Makefile
+   dft/simd/rvv512/Makefile
+   dft/simd/rvv1024/Makefile
 
    rdft/Makefile
    rdft/scalar/Makefile
@@ -790,6 +800,10 @@ AC_CONFIG_FILES([
    rdft/simd/neon/Makefile
    rdft/simd/generic-simd128/Makefile
    rdft/simd/generic-simd256/Makefile
+   rdft/simd/rvv128/Makefile
+   rdft/simd/rvv256/Makefile
+   rdft/simd/rvv512/Makefile
+   rdft/simd/rvv1024/Makefile
 
    reodft/Makefile
 

--- a/dft/codelet-dft.h
+++ b/dft/codelet-dft.h
@@ -108,5 +108,9 @@ extern const solvtab X(solvtab_dft_vsx);
 extern const solvtab X(solvtab_dft_neon);
 extern const solvtab X(solvtab_dft_generic_simd128);
 extern const solvtab X(solvtab_dft_generic_simd256);
+extern const solvtab X(solvtab_dft_rvv128);
+extern const solvtab X(solvtab_dft_rvv256);
+extern const solvtab X(solvtab_dft_rvv512);
+extern const solvtab X(solvtab_dft_rvv1024);
 
 #endif				/* __DFT_CODELET_H__ */

--- a/dft/conf.c
+++ b/dft/conf.c
@@ -85,4 +85,15 @@ void X(dft_conf_standard)(planner *p)
 #if HAVE_GENERIC_SIMD256
      X(solvtab_exec)(X(solvtab_dft_generic_simd256), p);
 #endif
+
+#if HAVE_RVV
+     if (X(have_simd_rvv)(128))
+          X(solvtab_exec)(X(solvtab_dft_rvv128), p);
+     if (X(have_simd_rvv)(256))
+          X(solvtab_exec)(X(solvtab_dft_rvv256), p);
+     if (X(have_simd_rvv)(512))
+          X(solvtab_exec)(X(solvtab_dft_rvv512), p);
+     if (X(have_simd_rvv)(1024))
+          X(solvtab_exec)(X(solvtab_dft_rvv1024), p);
+#endif
 }

--- a/dft/simd/Makefile.am
+++ b/dft/simd/Makefile.am
@@ -1,4 +1,4 @@
 AM_CPPFLAGS = -I $(top_srcdir)
-SUBDIRS = common sse2 avx avx-128-fma avx2 avx2-128 avx512 kcvi altivec vsx neon generic-simd128 generic-simd256
+SUBDIRS = common sse2 avx avx-128-fma avx2 avx2-128 avx512 kcvi altivec vsx neon generic-simd128 generic-simd256 rvv128 rvv256 rvv512 rvv1024
 EXTRA_DIST = n1b.h n1f.h n2b.h n2f.h n2s.h q1b.h q1f.h t1b.h t1bu.h	\
 t1f.h t1fu.h t2b.h t2f.h t3b.h t3f.h ts.h codlist.mk simd.mk

--- a/dft/simd/rvv1024/Makefile.am
+++ b/dft/simd/rvv1024/Makefile.am
@@ -1,0 +1,12 @@
+SIMD_HEADER=simd-support/simd-rvv1024.h
+
+include $(top_srcdir)/dft/simd/codlist.mk
+include $(top_srcdir)/dft/simd/simd.mk
+
+if HAVE_RVV
+
+BUILT_SOURCES = $(EXTRA_DIST)
+noinst_LTLIBRARIES = libdft_rvv1024_codelets.la
+libdft_rvv1024_codelets_la_SOURCES = $(BUILT_SOURCES)
+
+endif

--- a/dft/simd/rvv128/Makefile.am
+++ b/dft/simd/rvv128/Makefile.am
@@ -1,0 +1,12 @@
+SIMD_HEADER=simd-support/simd-rvv128.h
+
+include $(top_srcdir)/dft/simd/codlist.mk
+include $(top_srcdir)/dft/simd/simd.mk
+
+if HAVE_RVV
+
+BUILT_SOURCES = $(EXTRA_DIST)
+noinst_LTLIBRARIES = libdft_rvv128_codelets.la
+libdft_rvv128_codelets_la_SOURCES = $(BUILT_SOURCES)
+
+endif

--- a/dft/simd/rvv256/Makefile.am
+++ b/dft/simd/rvv256/Makefile.am
@@ -1,0 +1,12 @@
+SIMD_HEADER=simd-support/simd-rvv256.h
+
+include $(top_srcdir)/dft/simd/codlist.mk
+include $(top_srcdir)/dft/simd/simd.mk
+
+if HAVE_RVV
+
+BUILT_SOURCES = $(EXTRA_DIST)
+noinst_LTLIBRARIES = libdft_rvv256_codelets.la
+libdft_rvv256_codelets_la_SOURCES = $(BUILT_SOURCES)
+
+endif

--- a/dft/simd/rvv512/Makefile.am
+++ b/dft/simd/rvv512/Makefile.am
@@ -1,0 +1,12 @@
+SIMD_HEADER=simd-support/simd-rvv512.h
+
+include $(top_srcdir)/dft/simd/codlist.mk
+include $(top_srcdir)/dft/simd/simd.mk
+
+if HAVE_RVV
+
+BUILT_SOURCES = $(EXTRA_DIST)
+noinst_LTLIBRARIES = libdft_rvv512_codelets.la
+libdft_rvv512_codelets_la_SOURCES = $(BUILT_SOURCES)
+
+endif

--- a/doc/install.texi
+++ b/doc/install.texi
@@ -199,6 +199,7 @@ of the time).  @xref{Cycle Counters}.
 @code{--enable-altivec} (single),
 @code{--enable-vsx} (single, double),
 @code{--enable-neon} (single, double on aarch64),
+@code{--enable-rvv} (single, double on risc-v vector),
 @code{--enable-generic-simd128},
 and
 @code{--enable-generic-simd256}:

--- a/doc/intro.texi
+++ b/doc/intro.texi
@@ -18,7 +18,7 @@ transform (DFT) and various special cases thereof.
 
 @item  FFTW supports arbitrary multi-dimensional data.
 
-@item  FFTW supports the SSE, SSE2, AVX, AVX2, AVX512, KCVI, Altivec, VSX, and
+@item  FFTW supports the SSE, SSE2, AVX, AVX2, AVX512, KCVI, Altivec, VSX, RISC-V V, and
        NEON vector instruction sets.
 
 @item  FFTW includes parallel (multi-threaded) transforms

--- a/doc/other.texi
+++ b/doc/other.texi
@@ -16,7 +16,7 @@ special operations supported by some processors to perform a single
 operation on several numbers (usually 2 or 4) simultaneously.  SIMD
 floating-point instructions are available on several popular CPUs:
 SSE/SSE2/AVX/AVX2/AVX512/KCVI on some x86/x86-64 processors, AltiVec and
-VSX on some POWER/PowerPCs, NEON on some ARM models.  FFTW can be
+VSX on some POWER/PowerPCs, NEON on some ARM models, V extension on some RISC-V models.  FFTW can be
 compiled to support the SIMD instructions on any of these systems.
 @cindex SIMD
 @cindex SSE

--- a/kernel/ifftw.h
+++ b/kernel/ifftw.h
@@ -104,7 +104,7 @@ extern void X(extract_reim)(int sign, R *c, R **r, R **i);
       defined(HAVE_KCVI) || \
       defined(HAVE_ALTIVEC) || defined(HAVE_VSX) || \
       defined(HAVE_MIPS_PS) || \
-      defined(HAVE_GENERIC_SIMD128) || defined(HAVE_GENERIC_SIMD256)
+      defined(HAVE_GENERIC_SIMD128) || defined(HAVE_GENERIC_SIMD256) || defined(HAVE_RVV)
 #define HAVE_SIMD 1
 #else
 #define HAVE_SIMD 0
@@ -119,6 +119,7 @@ extern int X(have_simd_avx512)(void);
 extern int X(have_simd_altivec)(void);
 extern int X(have_simd_vsx)(void);
 extern int X(have_simd_neon)(void);
+extern int X(have_simd_rvv)(int);
 
 /* forward declarations */
 typedef struct problem_s problem;

--- a/rdft/codelet-rdft.h
+++ b/rdft/codelet-rdft.h
@@ -147,6 +147,10 @@ extern const solvtab X(solvtab_rdft_vsx);
 extern const solvtab X(solvtab_rdft_neon);
 extern const solvtab X(solvtab_rdft_generic_simd128);
 extern const solvtab X(solvtab_rdft_generic_simd256);
+extern const solvtab X(solvtab_rdft_rvv128);
+extern const solvtab X(solvtab_rdft_rvv256);
+extern const solvtab X(solvtab_rdft_rvv512);
+extern const solvtab X(solvtab_rdft_rvv1024);
 
 /* real-input & output DFT-like codelets (DHT, etc.) */
 typedef struct kr2r_desc_s kr2r_desc;

--- a/rdft/conf.c
+++ b/rdft/conf.c
@@ -102,4 +102,14 @@ void X(rdft_conf_standard)(planner *p)
 #if HAVE_GENERIC_SIMD256
      X(solvtab_exec)(X(solvtab_rdft_generic_simd256), p);
 #endif
+#if HAVE_RVV
+	 if (X(have_simd_rvv)(128))
+          X(solvtab_exec)(X(solvtab_rdft_rvv128), p);
+     if (X(have_simd_rvv)(256))
+          X(solvtab_exec)(X(solvtab_rdft_rvv256), p);
+     if (X(have_simd_rvv)(512))
+          X(solvtab_exec)(X(solvtab_rdft_rvv512), p);
+     if (X(have_simd_rvv)(1024))
+          X(solvtab_exec)(X(solvtab_rdft_rvv1024), p);
+#endif
 }

--- a/rdft/simd/Makefile.am
+++ b/rdft/simd/Makefile.am
@@ -1,4 +1,4 @@
 
 AM_CPPFLAGS = -I $(top_srcdir)
-SUBDIRS = common sse2 avx avx-128-fma avx2 avx2-128 avx512 kcvi altivec vsx neon generic-simd128 generic-simd256
+SUBDIRS = common sse2 avx avx-128-fma avx2 avx2-128 avx512 kcvi altivec vsx neon generic-simd128 generic-simd256 rvv128 rvv256 rvv512 rvv1024
 EXTRA_DIST = hc2cbv.h hc2cfv.h codlist.mk simd.mk

--- a/rdft/simd/rvv1024/Makefile.am
+++ b/rdft/simd/rvv1024/Makefile.am
@@ -1,0 +1,12 @@
+SIMD_HEADER=simd-support/simd-rvv1024.h
+
+include $(top_srcdir)/rdft/simd/codlist.mk
+include $(top_srcdir)/rdft/simd/simd.mk
+
+if HAVE_RVV
+
+noinst_LTLIBRARIES = librdft_rvv1024_codelets.la
+BUILT_SOURCES = $(EXTRA_DIST)
+librdft_rvv1024_codelets_la_SOURCES = $(BUILT_SOURCES)
+
+endif

--- a/rdft/simd/rvv128/Makefile.am
+++ b/rdft/simd/rvv128/Makefile.am
@@ -1,0 +1,12 @@
+SIMD_HEADER=simd-support/simd-rvv128.h
+
+include $(top_srcdir)/rdft/simd/codlist.mk
+include $(top_srcdir)/rdft/simd/simd.mk
+
+if HAVE_RVV
+
+noinst_LTLIBRARIES = librdft_rvv128_codelets.la
+BUILT_SOURCES = $(EXTRA_DIST)
+librdft_rvv128_codelets_la_SOURCES = $(BUILT_SOURCES)
+
+endif

--- a/rdft/simd/rvv256/Makefile.am
+++ b/rdft/simd/rvv256/Makefile.am
@@ -1,0 +1,12 @@
+SIMD_HEADER=simd-support/simd-rvv256.h
+
+include $(top_srcdir)/rdft/simd/codlist.mk
+include $(top_srcdir)/rdft/simd/simd.mk
+
+if HAVE_RVV
+
+noinst_LTLIBRARIES = librdft_rvv256_codelets.la
+BUILT_SOURCES = $(EXTRA_DIST)
+librdft_rvv256_codelets_la_SOURCES = $(BUILT_SOURCES)
+
+endif

--- a/rdft/simd/rvv512/Makefile.am
+++ b/rdft/simd/rvv512/Makefile.am
@@ -1,0 +1,12 @@
+SIMD_HEADER=simd-support/simd-rvv512.h
+
+include $(top_srcdir)/rdft/simd/codlist.mk
+include $(top_srcdir)/rdft/simd/simd.mk
+
+if HAVE_RVV
+
+noinst_LTLIBRARIES = librdft_rvv512_codelets.la
+BUILT_SOURCES = $(EXTRA_DIST)
+librdft_rvv512_codelets_la_SOURCES = $(BUILT_SOURCES)
+
+endif

--- a/simd-support/Makefile.am
+++ b/simd-support/Makefile.am
@@ -11,5 +11,5 @@ avx512.c simd-avx512.h \
 kcvi.c simd-kcvi.h \
 altivec.c simd-altivec.h vsx.c simd-vsx.h \
 neon.c simd-neon.h \
-simd-generic128.h simd-generic256.h
-
+simd-generic128.h simd-generic256.h \
+rvv.c simd-rvv.h simd-rvv128.h simd-rvv256.h simd-rvv512.h simd-rvv1024.h

--- a/simd-support/rvv.c
+++ b/simd-support/rvv.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2003, 2007-14 Matteo Frigo
+ * Copyright (c) 2003, 2007-14 Massachusetts Institute of Technology
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+
+#include "kernel/ifftw.h"
+#include <riscv_vector.h>
+
+#if HAVE_RVV
+/* don't know how to autodetect RVV; assume it is present */
+  int X(have_simd_rvv)(int rs)
+  {
+       return vsetvlmax_e64m1() == (rs / 64);
+  }
+#endif

--- a/simd-support/simd-common.h
+++ b/simd-support/simd-common.h
@@ -60,6 +60,14 @@
 #    define ALIGNMENT 16
 #    define ALIGNMENTA 16
 #  endif
+#elif defined(HAVE_RVV)
+#  if defined(FFTW_SINGLE)
+#    define ALIGNMENT 8
+#    define ALIGNMENTA 16
+#  else
+#    define ALIGNMENT 16
+#    define ALIGNMENTA 16
+#  endif
 #endif
 
 #if HAVE_SIMD

--- a/simd-support/simd-rvv.h
+++ b/simd-support/simd-rvv.h
@@ -1,0 +1,429 @@
+/*
+ * Copyright (c) 2003, 2007-11 Matteo Frigo
+ * Copyright (c) 2003, 2007-11 Massachusetts Institute of Technology
+ *
+ * RISC-V V support implemented by Romain Dolbeau. (c) 2019 Romain Dolbeau
+ * Modified to support RVV spec v1.0 by Zheng Shuo. (c) 2022 Zheng Shuo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#if defined(FFTW_LDOUBLE) || defined(FFTW_QUAD)
+#error "RISC-V V vector instructions only works in single or double precision"
+#endif
+
+#ifdef FFTW_SINGLE
+#  define DS(d,s) s /* single-precision option */
+#  define TYPE(name) name ## _f32m1
+#  define TYPEUINT(name) name ## _u32m1
+#  define TYPEINTERPRETF2U(name) name ## _f32m1_u32m1
+#  define TYPEINTERPRETU2F(name) name ## _u32m1_f32m1
+#  define TYPEMEM(name) name ## e32_v_f32m1
+#else
+#  define DS(d,s) d /* double-precision option */
+#  define TYPE(name) name ## _f64m1
+#  define TYPEUINT(name) name ## _u64m1
+#  define TYPEINTERPRETF2U(name) name ## _f64m1_u64m1
+#  define TYPEINTERPRETU2F(name) name ## _u64m1_f64m1
+#  define TYPEMEM(name) name ## e64_v_f64m1
+#endif
+
+// vlen up to 1024 to support qemu 7.0.0
+#if RVV_VLEN == 1024
+#  define VL DS(8, 16)        /* SIMD complex vector length */
+#elif RVV_VLEN == 512
+#  define VL DS(4, 8)        /* SIMD complex vector length */
+#elif RVV_VLEN == 256
+#  define VL DS(2, 4)        /* SIMD complex vector length */
+#elif RVV_VLEN == 128
+#  define VL DS(1, 2)        /* SIMD complex vector length */
+#else
+#  error "RVV_VLEN must be a power of 2 between 128 and 1024 bits temporarily"
+#endif /* RVV_VLEN */
+
+#define SIMD_VSTRIDE_OKA(x) ((x) == 2) 
+#define SIMD_STRIDE_OKPAIR SIMD_STRIDE_OK
+
+#define ZERO DS(0.0, 0.0f)
+
+#include <riscv_vector.h>
+
+typedef DS(vfloat64m1_t, vfloat32m1_t) V;
+typedef DS(vuint64m1_t, vuint32m1_t) Vuint;
+
+#define VNEG(a)   TYPE(vfneg_v)(a, 2*VL)
+#define VADD(a, b) TYPE(vfadd_vv)(a, b, 2*VL)
+#define VSUB(a, b) TYPE(vfsub_vv)(a, b, 2*VL)
+#define VMUL(a, b) TYPE(vfmul_vv)(a, b, 2*VL)
+
+// generate (all 1, 0, all 1, 0, ...) to split real and imagine parts
+#define VPARTSPLIT TYPEUINT(vsub_vx)(TYPEUINT(vand_vx)(TYPEUINT(vid_v)(2*VL), 1, 2*VL), 1, 2*VL)
+
+static inline V VDUPL(const V x)
+{
+	Vuint partr = VPARTSPLIT; // (all 1, 0, all 1, 0, ...)
+	V xl = TYPEINTERPRETU2F(vreinterpret_v)(TYPEUINT(vand_vv)(TYPEINTERPRETF2U(vreinterpret_v)(x), partr, 2*VL)); // set odd elements to 0
+	return VADD(TYPE(vfslide1up_vf)(xl, ZERO, 2*VL), xl);
+}
+
+static inline V VDUPH(const V x)
+{
+	Vuint partr = VPARTSPLIT; // (all 1, 0, all 1, 0, ...)
+	Vuint parti = TYPEUINT(vnot_v)(partr, 2*VL); // (0, all 1, 0, all 1, ...)
+	V xh = TYPEINTERPRETU2F(vreinterpret_v)(TYPEUINT(vand_vv)(TYPEINTERPRETF2U(vreinterpret_v)(x), parti, 2*VL)); // set even elements to 0
+	return VADD(TYPE(vfslide1down_vf)(xh, ZERO, 2*VL), xh);
+}
+
+#define DVK(var, val) V var = TYPE(vfmv_v_f)(val, 2*VL)
+
+static inline V FLIP_RI(const V x)
+{
+	Vuint partr = VPARTSPLIT; // (all 1, 0, all 1, 0, ...)
+	V xl = TYPEINTERPRETU2F(vreinterpret_v)(TYPEUINT(vand_vv)(TYPEINTERPRETF2U(vreinterpret_v)(x), partr, 2*VL)); // set odd elements to 0
+	Vuint parti = TYPEUINT(vnot_v)(partr, 2*VL); // (0, all 1, 0, all 1, ...)
+	V xh = TYPEINTERPRETU2F(vreinterpret_v)(TYPEUINT(vand_vv)(TYPEINTERPRETF2U(vreinterpret_v)(x), parti, 2*VL)); // set even elements to 0
+	return VADD(TYPE(vfslide1down_vf)(xh, ZERO, 2*VL), TYPE(vfslide1up_vf)(xl, ZERO, 2*VL));
+}
+
+static inline V VCONJ(const V x)
+{
+	Vuint partr = VPARTSPLIT; // (all 1, 0, all 1, 0, ...)
+	V xl = TYPEINTERPRETU2F(vreinterpret_v)(TYPEUINT(vand_vv)(TYPEINTERPRETF2U(vreinterpret_v)(x), partr, 2*VL)); // set odd elements to 0
+	Vuint parti = TYPEUINT(vnot_v)(partr, 2*VL); // (0, all 1, 0, all 1, ...)
+	V xh = TYPEINTERPRETU2F(vreinterpret_v)(TYPEUINT(vand_vv)(TYPEINTERPRETF2U(vreinterpret_v)(x), parti, 2*VL)); // set even elements to 0
+	return VADD(xl, VNEG(xh));
+}
+
+static inline V VBYI(V x)
+{
+	Vuint partr = VPARTSPLIT; // (all 1, 0, all 1, 0, ...)
+	V xl = TYPEINTERPRETU2F(vreinterpret_v)(TYPEUINT(vand_vv)(TYPEINTERPRETF2U(vreinterpret_v)(x), partr, 2*VL)); // set odd elements to 0
+	Vuint parti = TYPEUINT(vnot_v)(partr, 2*VL); // (0, all 1, 0, all 1, ...)
+	V xh = TYPEINTERPRETU2F(vreinterpret_v)(TYPEUINT(vand_vv)(TYPEINTERPRETF2U(vreinterpret_v)(VNEG(x)), parti, 2*VL)); // set elements to negative, then set even elements to 0
+	return VADD(TYPE(vfslide1down_vf)(xh, ZERO, 2*VL), TYPE(vfslide1up_vf)(xl, ZERO, 2*VL));
+}
+
+#define LDK(x) x
+
+#define VFMA(a, b, c) TYPE(vfmacc_vv)(c, a, b, 2*VL)
+#define VFMS(a, b, c) TYPE(vfmsac_vv)(c, a, b, 2*VL)
+#define VFNMS(a, b, c) TYPE(vfnmsac_vv)(c, a, b, 2*VL)
+#define VFMAI(b, c) VADD(c, VBYI(b))
+#define VFNMSI(b, c) VSUB(c, VBYI(b))
+#define VFMACONJ(b, c) VADD(VCONJ(b), c)
+#define VFMSCONJ(b, c) VSUB(VCONJ(b), c)
+#define VFNMSCONJ(b, c) VSUB(c, VCONJ(b))
+
+static inline V VZMUL(V tx, V sr)
+{
+    V tr = VDUPL(tx);
+    V ti = VDUPH(tx);
+    tr = VMUL(sr, tr);
+    sr = VBYI(sr);
+    return VFMA(ti, sr, tr);
+}
+
+static inline V VZMULJ(V tx, V sr)
+{
+    V tr = VDUPL(tx);
+    V ti = VDUPH(tx);
+    tr = VMUL(sr, tr);
+    sr = VBYI(sr);
+    return VFNMS(ti, sr, tr);
+}
+
+static inline V VZMULI(V tx, V sr)
+{
+    V tr = VDUPL(tx);
+    V ti = VDUPH(tx);
+    ti = VMUL(ti, sr);
+    sr = VBYI(sr);
+    return VFMS(tr, sr, ti);
+}
+
+static inline V VZMULIJ(V tx, V sr)
+{
+    V tr = VDUPL(tx);
+    V ti = VDUPH(tx);
+    ti = VMUL(ti, sr);
+    sr = VBYI(sr);
+    return VFMA(tr, sr, ti);
+}
+
+static inline V LDA(const R *x, INT ivs, const R *aligned_like) {
+    (void)aligned_like; /* UNUSED */
+
+    return TYPEMEM(vl)(x, 2*VL);
+}
+
+static inline void STA(R *x, V v, INT ovs, const R *aligned_like) {
+    (void)aligned_like; /* UNUSED */
+
+    TYPEMEM(vs)(x, v, 2*VL);
+}
+
+static inline V LD(const R *x, INT ivs, const R *aligned_like)
+{
+	(void)aligned_like; /* UNUSED */
+
+	V xl = TYPEMEM(vls)(x, sizeof(R)*ivs, VL);
+	V xh = TYPEMEM(vls)(x+1, sizeof(R)*ivs, VL);
+
+	Vuint idx = TYPEUINT(vid_v)(2*VL); // (0, 1, 2, 3, ...)
+	Vuint idx1 = TYPEUINT(vand_vx)(idx, -2, 2*VL); // (0, 0, 2, 2, ...)
+	Vuint idx2 = TYPEUINT(vsrl_vx)(idx1, 1, 2*VL); // (0, 0, 1, 1, ...)
+
+	V xl1 = TYPE(vrgather_vv)(xl, idx2, 2*VL);
+	V xh1 = TYPE(vrgather_vv)(xh, idx2, 2*VL);
+
+	Vuint idx3 = TYPEUINT(vand_vx)(idx, 1, 2*VL); // (0, 1, 0, 1, ...)
+	Vuint idx4 = TYPEUINT(vsub_vx)(idx3, 1, 2*VL); // (all 1, 0, all 1, 0, ...)
+	Vuint idx5 = TYPEUINT(vnot_v)(idx4, 2*VL); // (0, all 1, 0, all 1, ...)
+
+	V xl2 = TYPEINTERPRETU2F(vreinterpret_v)(TYPEUINT(vand_vv)(TYPEINTERPRETF2U(vreinterpret_v)(xl1), idx4, 2*VL)); // set odd elements to 0
+	V xh2 = TYPEINTERPRETU2F(vreinterpret_v)(TYPEUINT(vand_vv)(TYPEINTERPRETF2U(vreinterpret_v)(xh1), idx5, 2*VL)); // set even elements to 0
+	return VADD(xl2, xh2);
+}
+
+static inline void ST(R *x, V v, INT ovs, const R *aligned_like)
+{
+	(void)aligned_like; /* UNUSED */
+
+	Vuint idx = TYPEUINT(vid_v)(VL); // (0, 1, 2, 3, ...)
+	Vuint idx1 = TYPEUINT(vsll_vx)(idx, 1, VL); // (0, 2, 4, 6, ...)
+
+	V vl = TYPE(vrgather_vv)(v, idx1, VL);
+	TYPEMEM(vss)(x, sizeof(R)*ovs, vl, ovs ? VL : 1); // if ovs=0, store the first element
+
+	Vuint idx2 = TYPEUINT(vadd_vx)(idx1, 1, VL); // (1, 3, 5, 7, ...)
+
+	V vh = TYPE(vrgather_vv)(v, idx2, VL);
+	TYPEMEM(vss)(x+1, sizeof(R)*ovs, vh, ovs ? VL : 1); // if ovs=0, store the first element
+}
+
+// only one of STM2 and STN2 should be implemented, according to the hardware. Both micros occur in the code, and the implemented one does some operations, while the no-op one is skipped.
+#define STM2(x, v, ovs, a) ST(x, v, ovs, a)
+
+#define STN2(x, v0, v1, ovs) /* no-op */
+
+// only one of STM4 and STN4 should be implemented. See STM2 and STN2.
+#define STM4(x, v, ovs, a) TYPEMEM(vss)(x, sizeof(R)*ovs, v, 2*VL)
+
+#define STN4(x, v0, v1, v2, v3, ovs)  /* no-op */
+
+/* twiddle storage #1: compact, slower */
+#ifdef FFTW_SINGLE
+#  if RVV_VLEN == 1024
+#    define VTW1(v,x) {TW_CEXP, v, x}, {TW_CEXP, v+1, x}, {TW_CEXP, v+2, x}, {TW_CEXP, v+3, x}, \
+		      {TW_CEXP, v+4, x}, {TW_CEXP, v+5, x}, {TW_CEXP, v+6, x}, {TW_CEXP, v+7, x}, \
+		      {TW_CEXP, v+8, x}, {TW_CEXP, v+9, x}, {TW_CEXP, v+10, x}, {TW_CEXP, v+11, x}, \
+		      {TW_CEXP, v+12, x}, {TW_CEXP, v+13, x}, {TW_CEXP, v+14, x}, {TW_CEXP, v+15, x}
+#  elif RVV_VLEN == 512
+#    define VTW1(v,x) {TW_CEXP, v, x}, {TW_CEXP, v+1, x}, {TW_CEXP, v+2, x}, {TW_CEXP, v+3, x}, \
+		      {TW_CEXP, v+4, x}, {TW_CEXP, v+5, x}, {TW_CEXP, v+6, x}, {TW_CEXP, v+7, x}
+#  elif RVV_VLEN == 256
+#    define VTW1(v,x) {TW_CEXP, v, x}, {TW_CEXP, v+1, x}, {TW_CEXP, v+2, x}, {TW_CEXP, v+3, x}
+#  elif RVV_VLEN == 128
+#    define VTW1(v,x) {TW_CEXP, v, x}, {TW_CEXP, v+1, x}
+#  else
+#    error "RVV_VLEN must be a power of 2 between 128 and 1024 bits temporarily"
+#  endif /* RVV_VLEN */
+#else
+#  if RVV_VLEN == 1024
+#    define VTW1(v,x) {TW_CEXP, v, x}, {TW_CEXP, v+1, x}, {TW_CEXP, v+2, x}, {TW_CEXP, v+3, x}, \
+		      {TW_CEXP, v+4, x}, {TW_CEXP, v+5, x}, {TW_CEXP, v+6, x}, {TW_CEXP, v+7, x}
+#  elif RVV_VLEN == 512
+#    define VTW1(v,x) {TW_CEXP, v, x}, {TW_CEXP, v+1, x}, {TW_CEXP, v+2, x}, {TW_CEXP, v+3, x}
+#  elif RVV_VLEN == 256
+#    define VTW1(v,x) {TW_CEXP, v, x}, {TW_CEXP, v+1, x}
+#  elif RVV_VLEN == 128
+#    define VTW1(v,x) {TW_CEXP, v, x}
+#  else
+#    error "RVV_VLEN must be a power of 2 between 128 and 1024 bits temporarily"
+#  endif /* RVV_VLEN */
+#endif
+
+#define TWVL1 (VL)
+
+static inline V BYTW1(const R *t, V sr)
+{
+     return VZMUL(LDA(t, 2, t), sr);
+}
+
+static inline V BYTWJ1(const R *t, V sr)
+{
+     return VZMULJ(LDA(t, 2, t), sr);
+}
+
+/* twiddle storage #2: twice the space, faster (when in cache) */
+#ifdef FFTW_SINGLE
+#  if RVV_VLEN == 1024
+#    define VTW2(v,x) {TW_COS, v+0, x}, {TW_COS, v+0, x}, {TW_COS, v+1, x}, {TW_COS, v+1, x}, \
+		      {TW_COS, v+2, x}, {TW_COS, v+2, x}, {TW_COS, v+3, x}, {TW_COS, v+3, x}, \
+		      {TW_COS, v+4, x}, {TW_COS, v+4, x}, {TW_COS, v+5, x}, {TW_COS, v+5, x}, \
+		      {TW_COS, v+6, x}, {TW_COS, v+6, x}, {TW_COS, v+7, x}, {TW_COS, v+7, x}, \
+		      {TW_COS, v+8, x}, {TW_COS, v+8, x}, {TW_COS, v+9, x}, {TW_COS, v+9, x}, \
+		      {TW_COS, v+10, x}, {TW_COS, v+10, x}, {TW_COS, v+11, x}, {TW_COS, v+11, x}, \
+		      {TW_COS, v+12, x}, {TW_COS, v+12, x}, {TW_COS, v+13, x}, {TW_COS, v+13, x}, \
+		      {TW_COS, v+14, x}, {TW_COS, v+14, x}, {TW_COS, v+15, x}, {TW_COS, v+15, x}, \
+		      {TW_SIN, v+0, -x}, {TW_SIN, v+0, x}, {TW_SIN, v+1, -x}, {TW_SIN, v+1, x}, \
+		      {TW_SIN, v+2, -x}, {TW_SIN, v+2, x}, {TW_SIN, v+3, -x}, {TW_SIN, v+3, x}, \
+		      {TW_SIN, v+4, -x}, {TW_SIN, v+4, x}, {TW_SIN, v+5, -x}, {TW_SIN, v+5, x}, \
+		      {TW_SIN, v+6, -x}, {TW_SIN, v+6, x}, {TW_SIN, v+7, -x}, {TW_SIN, v+7, x}, \
+		      {TW_SIN, v+8, -x}, {TW_SIN, v+8, x}, {TW_SIN, v+9, -x}, {TW_SIN, v+9, x}, \
+		      {TW_SIN, v+10, -x}, {TW_SIN, v+10, x}, {TW_SIN, v+11, -x}, {TW_SIN, v+11, x}, \
+		      {TW_SIN, v+12, -x}, {TW_SIN, v+12, x}, {TW_SIN, v+13, -x}, {TW_SIN, v+13, x}, \
+		      {TW_SIN, v+14, -x}, {TW_SIN, v+14, x}, {TW_SIN, v+15, -x}, {TW_SIN, v+15, x}
+#  elif RVV_VLEN == 512
+#    define VTW2(v,x) {TW_COS, v+0, x}, {TW_COS, v+0, x}, {TW_COS, v+1, x}, {TW_COS, v+1, x}, \
+		      {TW_COS, v+2, x}, {TW_COS, v+2, x}, {TW_COS, v+3, x}, {TW_COS, v+3, x}, \
+		      {TW_COS, v+4, x}, {TW_COS, v+4, x}, {TW_COS, v+5, x}, {TW_COS, v+5, x}, \
+		      {TW_COS, v+6, x}, {TW_COS, v+6, x}, {TW_COS, v+7, x}, {TW_COS, v+7, x}, \
+		      {TW_SIN, v+0, -x}, {TW_SIN, v+0, x}, {TW_SIN, v+1, -x}, {TW_SIN, v+1, x}, \
+		      {TW_SIN, v+2, -x}, {TW_SIN, v+2, x}, {TW_SIN, v+3, -x}, {TW_SIN, v+3, x}, \
+		      {TW_SIN, v+4, -x}, {TW_SIN, v+4, x}, {TW_SIN, v+5, -x}, {TW_SIN, v+5, x}, \
+		      {TW_SIN, v+6, -x}, {TW_SIN, v+6, x}, {TW_SIN, v+7, -x}, {TW_SIN, v+7, x}
+#  elif RVV_VLEN == 256
+#    define VTW2(v,x) {TW_COS, v+0, x}, {TW_COS, v+0, x}, {TW_COS, v+1, x}, {TW_COS, v+1, x}, \
+		      {TW_COS, v+2, x}, {TW_COS, v+2, x}, {TW_COS, v+3, x}, {TW_COS, v+3, x}, \
+		      {TW_SIN, v+0, -x}, {TW_SIN, v+0, x}, {TW_SIN, v+1, -x}, {TW_SIN, v+1, x}, \
+		      {TW_SIN, v+2, -x}, {TW_SIN, v+2, x}, {TW_SIN, v+3, -x}, {TW_SIN, v+3, x}
+#  elif RVV_VLEN == 128
+#    define VTW2(v,x) {TW_COS, v+0, x}, {TW_COS, v+0, x}, {TW_COS, v+1, x}, {TW_COS, v+1, x}, \
+		      {TW_SIN, v+0, -x}, {TW_SIN, v+0, x}, {TW_SIN, v+1, -x}, {TW_SIN, v+1, x}
+#  else
+#    error "RVV_VLEN must be a power of 2 between 128 and 1024 bits temporarily"
+#  endif /* RVV_VLEN */
+#else
+#  if RVV_VLEN == 1024
+#    define VTW2(v,x) {TW_COS, v+0, x}, {TW_COS, v+0, x}, {TW_COS, v+1, x}, {TW_COS, v+1, x}, \
+		      {TW_COS, v+2, x}, {TW_COS, v+2, x}, {TW_COS, v+3, x}, {TW_COS, v+3, x}, \
+		      {TW_COS, v+4, x}, {TW_COS, v+4, x}, {TW_COS, v+5, x}, {TW_COS, v+5, x}, \
+		      {TW_COS, v+6, x}, {TW_COS, v+6, x}, {TW_COS, v+7, x}, {TW_COS, v+7, x}, \
+		      {TW_SIN, v+0, -x}, {TW_SIN, v+0, x}, {TW_SIN, v+1, -x}, {TW_SIN, v+1, x}, \
+		      {TW_SIN, v+2, -x}, {TW_SIN, v+2, x}, {TW_SIN, v+3, -x}, {TW_SIN, v+3, x}, \
+		      {TW_SIN, v+4, -x}, {TW_SIN, v+4, x}, {TW_SIN, v+5, -x}, {TW_SIN, v+5, x}, \
+		      {TW_SIN, v+6, -x}, {TW_SIN, v+6, x}, {TW_SIN, v+7, -x}, {TW_SIN, v+7, x}
+#  elif RVV_VLEN == 512
+#    define VTW2(v,x) {TW_COS, v+0, x}, {TW_COS, v+0, x}, {TW_COS, v+1, x}, {TW_COS, v+1, x}, \
+		      {TW_COS, v+2, x}, {TW_COS, v+2, x}, {TW_COS, v+3, x}, {TW_COS, v+3, x}, \
+		      {TW_SIN, v+0, -x}, {TW_SIN, v+0, x}, {TW_SIN, v+1, -x}, {TW_SIN, v+1, x}, \
+		      {TW_SIN, v+2, -x}, {TW_SIN, v+2, x}, {TW_SIN, v+3, -x}, {TW_SIN, v+3, x}
+#  elif RVV_VLEN == 256
+#    define VTW2(v,x) {TW_COS, v+0, x}, {TW_COS, v+0, x}, {TW_COS, v+1, x}, {TW_COS, v+1, x}, \
+		      {TW_SIN, v+0, -x}, {TW_SIN, v+0, x}, {TW_SIN, v+1, -x}, {TW_SIN, v+1, x}
+#  elif RVV_VLEN == 128
+#    define VTW2(v,x) {TW_COS, v+0, x}, {TW_COS, v+0, x}, {TW_SIN, v+0, -x}, {TW_SIN, v+0, x}
+#  else
+#    error "RVV_VLEN must be a power of 2 between 128 and 1024 bits temporarily"
+#  endif /* RVV_VLEN */
+#endif
+
+#define TWVL2 (2*VL)
+
+static inline V BYTW2(const R *t, V sr)
+{
+    V si = FLIP_RI(sr);
+    V ti = LDA(t+2*VL, 2, t+4*VL);
+    V tr = LDA(t, 2, t);
+    return VFMA(tr, sr, VMUL(ti, si));
+}
+
+static inline V BYTWJ2(const R *t, V sr)
+{
+    V si = FLIP_RI(sr);
+    V ti = LDA(t+2*VL, 2, t+4*VL);
+    V tr = LDA(t, 2, t);
+    return VFNMS(ti, si, VMUL(tr, sr));
+}
+
+/* twiddle storage #3 */
+#define VTW3(v,x) VTW1(v,x)
+#define TWVL3 TWVL1
+
+/* twiddle storage for split arrays */
+#ifdef FFTW_SINGLE
+#  if RVV_VLEN == 1024
+#    define VTWS(v,x) {TW_COS, v+0, x}, {TW_COS, v+1, x}, {TW_COS, v+2, x}, {TW_COS, v+3, x}, \
+		      {TW_COS, v+4, x}, {TW_COS, v+5, x}, {TW_COS, v+6, x}, {TW_COS, v+7, x}, \
+		      {TW_COS, v+8, x}, {TW_COS, v+9, x}, {TW_COS, v+10, x}, {TW_COS, v+11, x}, \
+		      {TW_COS, v+12, x}, {TW_COS, v+13, x}, {TW_COS, v+14, x}, {TW_COS, v+15, x}, \
+		      {TW_COS, v+16, x}, {TW_COS, v+17, x}, {TW_COS, v+18, x}, {TW_COS, v+19, x}, \
+		      {TW_COS, v+20, x}, {TW_COS, v+21, x}, {TW_COS, v+22, x}, {TW_COS, v+23, x}, \
+		      {TW_COS, v+24, x}, {TW_COS, v+25, x}, {TW_COS, v+26, x}, {TW_COS, v+27, x}, \
+		      {TW_COS, v+28, x}, {TW_COS, v+29, x}, {TW_COS, v+30, x}, {TW_COS, v+31, x}, \
+		      {TW_SIN, v+0, x}, {TW_SIN, v+1, x}, {TW_SIN, v+2, x}, {TW_SIN, v+3, x}, \
+		      {TW_SIN, v+4, x}, {TW_SIN, v+5, x}, {TW_SIN, v+6, x}, {TW_SIN, v+7, x}, \
+		      {TW_SIN, v+8, x}, {TW_SIN, v+9, x}, {TW_SIN, v+10, x}, {TW_SIN, v+11, x}, \
+		      {TW_SIN, v+12, x}, {TW_SIN, v+13, x}, {TW_SIN, v+14, x}, {TW_SIN, v+15, x}, \
+		      {TW_SIN, v+16, x}, {TW_SIN, v+17, x}, {TW_SIN, v+18, x}, {TW_SIN, v+19, x}, \
+		      {TW_SIN, v+20, x}, {TW_SIN, v+21, x}, {TW_SIN, v+22, x}, {TW_SIN, v+23, x}, \
+		      {TW_SIN, v+24, x}, {TW_SIN, v+25, x}, {TW_SIN, v+26, x}, {TW_SIN, v+27, x}, \
+		      {TW_SIN, v+28, x}, {TW_SIN, v+29, x}, {TW_SIN, v+30, x}, {TW_SIN, v+31, x}
+#  elif RVV_VLEN == 512
+#    define VTWS(v,x) {TW_COS, v+0, x}, {TW_COS, v+1, x}, {TW_COS, v+2, x}, {TW_COS, v+3, x}, \
+		      {TW_COS, v+4, x}, {TW_COS, v+5, x}, {TW_COS, v+6, x}, {TW_COS, v+7, x}, \
+		      {TW_COS, v+8, x}, {TW_COS, v+9, x}, {TW_COS, v+10, x}, {TW_COS, v+11, x}, \
+		      {TW_COS, v+12, x}, {TW_COS, v+13, x}, {TW_COS, v+14, x}, {TW_COS, v+15, x}, \
+		      {TW_SIN, v+0, x}, {TW_SIN, v+1, x}, {TW_SIN, v+2, x}, {TW_SIN, v+3, x}, \
+		      {TW_SIN, v+4, x}, {TW_SIN, v+5, x}, {TW_SIN, v+6, x}, {TW_SIN, v+7, x}, \
+		      {TW_SIN, v+8, x}, {TW_SIN, v+9, x}, {TW_SIN, v+10, x}, {TW_SIN, v+11, x}, \
+		      {TW_SIN, v+12, x}, {TW_SIN, v+13, x}, {TW_SIN, v+14, x}, {TW_SIN, v+15, x}
+#  elif RVV_VLEN == 256
+#    define VTWS(v,x) {TW_COS, v+0, x}, {TW_COS, v+1, x}, {TW_COS, v+2, x}, {TW_COS, v+3, x}, \
+		      {TW_COS, v+4, x}, {TW_COS, v+5, x}, {TW_COS, v+6, x}, {TW_COS, v+7, x}, \
+		      {TW_SIN, v+0, x}, {TW_SIN, v+1, x}, {TW_SIN, v+2, x}, {TW_SIN, v+3, x}, \
+		      {TW_SIN, v+4, x}, {TW_SIN, v+5, x}, {TW_SIN, v+6, x}, {TW_SIN, v+7, x}
+#  elif RVV_VLEN == 128
+#    define VTWS(v,x) {TW_COS, v+0, x}, {TW_COS, v+1, x}, {TW_COS, v+2, x}, {TW_COS, v+3, x}, \
+		      {TW_SIN, v+0, x}, {TW_SIN, v+1, x}, {TW_SIN, v+2, x}, {TW_SIN, v+3, x}
+#  else
+#    error "RVV_VLEN must be a power of 2 between 128 and 1024 bits temporarily"
+#  endif /* RVV_VLEN */
+#else
+#  if RVV_VLEN == 1024
+#    define VTWS(v,x) {TW_COS, v+0, x}, {TW_COS, v+1, x}, {TW_COS, v+2, x}, {TW_COS, v+3, x}, \
+		      {TW_COS, v+4, x}, {TW_COS, v+5, x}, {TW_COS, v+6, x}, {TW_COS, v+7, x}, \
+		      {TW_COS, v+8, x}, {TW_COS, v+9, x}, {TW_COS, v+10, x}, {TW_COS, v+11, x}, \
+		      {TW_COS, v+12, x}, {TW_COS, v+13, x}, {TW_COS, v+14, x}, {TW_COS, v+15, x}, \
+		      {TW_SIN, v+0, x}, {TW_SIN, v+1, x}, {TW_SIN, v+2, x}, {TW_SIN, v+3, x}, \
+		      {TW_SIN, v+4, x}, {TW_SIN, v+5, x}, {TW_SIN, v+6, x}, {TW_SIN, v+7, x}, \
+		      {TW_SIN, v+8, x}, {TW_SIN, v+9, x}, {TW_SIN, v+10, x}, {TW_SIN, v+11, x}, \
+		      {TW_SIN, v+12, x}, {TW_SIN, v+13, x}, {TW_SIN, v+14, x}, {TW_SIN, v+15, x}
+#  elif RVV_VLEN == 512
+#    define VTWS(v,x) {TW_COS, v+0, x}, {TW_COS, v+1, x}, {TW_COS, v+2, x}, {TW_COS, v+3, x}, \
+		      {TW_COS, v+4, x}, {TW_COS, v+5, x}, {TW_COS, v+6, x}, {TW_COS, v+7, x}, \
+		      {TW_SIN, v+0, x}, {TW_SIN, v+1, x}, {TW_SIN, v+2, x}, {TW_SIN, v+3, x}, \
+		      {TW_SIN, v+4, x}, {TW_SIN, v+5, x}, {TW_SIN, v+6, x}, {TW_SIN, v+7, x}
+#  elif RVV_VLEN == 256
+#    define VTWS(v,x) {TW_COS, v+0, x}, {TW_COS, v+1, x}, {TW_COS, v+2, x}, {TW_COS, v+3, x}, \
+		      {TW_SIN, v+0, x}, {TW_SIN, v+1, x}, {TW_SIN, v+2, x}, {TW_SIN, v+3, x}
+#  elif RVV_VLEN == 128
+#    define VTWS(v,x) {TW_COS, v+0, x}, {TW_COS, v+1, x}, {TW_SIN, v+0, x}, {TW_SIN, v+1, x}
+#  else
+#    error "RVV_VLEN must be a power of 2 between 128 and 1024 bits temporarily"
+#  endif /* RVV_VLEN */
+#endif
+
+#define TWVLS (2*VL)
+
+#define VLEAVE() /* nothing */
+
+#include "simd-common.h"

--- a/simd-support/simd-rvv1024.h
+++ b/simd-support/simd-rvv1024.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2003, 2007-11 Matteo Frigo
+ * Copyright (c) 2003, 2007-11 Massachusetts Institute of Technology
+ *
+ * RISC-V V support implemented by Romain Dolbeau. (c) 2019 Romain Dolbeau
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#define SIMD_SUFFIX  _rvv1024  /* for renaming */
+#define RVV_VLEN 1024
+#include "simd-rvv.h"

--- a/simd-support/simd-rvv128.h
+++ b/simd-support/simd-rvv128.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2003, 2007-11 Matteo Frigo
+ * Copyright (c) 2003, 2007-11 Massachusetts Institute of Technology
+ *
+ * RISC-V V support implemented by Romain Dolbeau. (c) 2019 Romain Dolbeau
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#define SIMD_SUFFIX  _rvv128  /* for renaming */
+#define RVV_VLEN 128
+#include "simd-rvv.h"

--- a/simd-support/simd-rvv256.h
+++ b/simd-support/simd-rvv256.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2003, 2007-11 Matteo Frigo
+ * Copyright (c) 2003, 2007-11 Massachusetts Institute of Technology
+ *
+ * RISC-V V support implemented by Romain Dolbeau. (c) 2019 Romain Dolbeau
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#define SIMD_SUFFIX  _rvv256  /* for renaming */
+#define RVV_VLEN 256
+#include "simd-rvv.h"

--- a/simd-support/simd-rvv512.h
+++ b/simd-support/simd-rvv512.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2003, 2007-11 Matteo Frigo
+ * Copyright (c) 2003, 2007-11 Massachusetts Institute of Technology
+ *
+ * RISC-V V support implemented by Romain Dolbeau. (c) 2019 Romain Dolbeau
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#define SIMD_SUFFIX  _rvv512  /* for renaming */
+#define RVV_VLEN 512
+#include "simd-rvv.h"


### PR DESCRIPTION
Enable rvv 1.0 with --enable-rvv.
Correctness tests are done with bench --verify on qemu.