### PR TITLE
add fftw_copy_plan

### DIFF
--- a/api/api.h
+++ b/api/api.h
@@ -62,6 +62,7 @@ extern "C"
 struct X(plan_s) {
      plan *pln;
      problem *prb;
+     size_t refcount;
      int sign;
 };
 
@@ -107,7 +108,7 @@ apiplan *X(mkapiplan)(int sign, unsigned flags, problem *prb);
 rdft_kind *X(map_r2r_kind)(int rank, const X(r2r_kind) * kind);
 
 typedef void (*planner_hook_t)(void);
-                                                     
+
 void X(set_planner_hooks)(planner_hook_t before, planner_hook_t after);
 
 #ifdef __cplusplus

--- a/api/apiplan.c
+++ b/api/apiplan.c
@@ -52,7 +52,7 @@ static plan *mkplan(planner *plnr, unsigned flags,
 		    const problem *prb, unsigned hash_info)
 {
      plan *pln;
-     
+
      pln = mkplan0(plnr, flags, prb, hash_info, WISDOM_NORMAL);
 
      if (plnr->wisdom_state == WISDOM_NORMAL && !pln) {
@@ -93,10 +93,10 @@ apiplan *X(mkapiplan)(int sign, unsigned flags, problem *prb)
                                          FFTW_PATIENT, FFTW_EXHAUSTIVE};
      int pat, pat_max;
      double pcost = 0;
-     
+
      if (before_planner_hook)
           before_planner_hook();
-     
+
      plnr = X(the_planner)();
 
      if (flags & FFTW_WISDOM_ONLY) {
@@ -140,6 +140,7 @@ apiplan *X(mkapiplan)(int sign, unsigned flags, problem *prb)
 	  /* build apiplan */
 	  p = (apiplan *) MALLOC(sizeof(apiplan), PLANS);
 	  p->prb = prb;
+	  p->refcount = 1u;
 	  p->sign = sign; /* cache for execute_dft */
 
 	  /* re-create plan from wisdom, adding blessing */
@@ -172,8 +173,22 @@ apiplan *X(mkapiplan)(int sign, unsigned flags, problem *prb)
 
      if (after_planner_hook)
           after_planner_hook();
-     
+
      return p;
+}
+
+X(plan) X(copy_plan)(X(plan) p)
+{
+     if (p) {
+          if (before_planner_hook)
+               before_planner_hook();
+
+          p->refcount++;
+
+          if (after_planner_hook)
+               after_planner_hook();
+     }
+	 return p;
 }
 
 void X(destroy_plan)(X(plan) p)
@@ -181,11 +196,13 @@ void X(destroy_plan)(X(plan) p)
      if (p) {
           if (before_planner_hook)
                before_planner_hook();
-     
-          X(plan_awake)(p->pln, SLEEPY);
-          X(plan_destroy_internal)(p->pln);
-          X(problem_destroy)(p->prb);
-          X(ifree)(p);
+
+          if (p->refcount-- == 1u) {
+               X(plan_awake)(p->pln, SLEEPY);
+               X(plan_destroy_internal)(p->pln);
+               X(problem_destroy)(p->prb);
+               X(ifree)(p);
+          }
 
           if (after_planner_hook)
                after_planner_hook();

--- a/api/apiplan.c
+++ b/api/apiplan.c
@@ -188,7 +188,7 @@ X(plan) X(copy_plan)(X(plan) p)
           if (after_planner_hook)
                after_planner_hook();
      }
-	 return p;
+     return p;
 }
 
 void X(destroy_plan)(X(plan) p)

--- a/api/f77funcs.h
+++ b/api/f77funcs.h
@@ -34,6 +34,11 @@ FFTW_VOIDFUNC F77(destroy_plan, DESTROY_PLAN)(X(plan) *p)
      X(destroy_plan)(*p);
 }
 
+FFTW_VOIDFUNC F77(copy_plan, COPY_PLAN)(X(plan) *pcopy, X(plan) *p)
+{
+     *pcopy = X(copy_plan)(*p);
+}
+
 FFTW_VOIDFUNC F77(cleanup, CLEANUP)(void)
 {
      X(cleanup)();
@@ -395,7 +400,7 @@ FFTW_VOIDFUNC F77(plan_r2r_1d, PLAN_R2R_1D)(X(plan) *p, int *n, R *in, R *out,
 }
 
 FFTW_VOIDFUNC F77(plan_r2r_2d, PLAN_R2R_2D)(X(plan) *p, int *nx, int *ny,
-				   R *in, R *out, 
+				   R *in, R *out,
 				   int *kindx, int *kindy, int *flags)
 {
      *p = X(plan_r2r_2d)(*ny, *nx, in, out,
@@ -409,7 +414,7 @@ FFTW_VOIDFUNC F77(plan_r2r_3d, PLAN_R2R_3D)(X(plan) *p,
 				   int *flags)
 {
      *p = X(plan_r2r_3d)(*nz, *ny, *nx, in, out,
-			 (X(r2r_kind)) *kindz, (X(r2r_kind)) *kindy, 
+			 (X(r2r_kind)) *kindz, (X(r2r_kind)) *kindy,
 			 (X(r2r_kind)) *kindx, *flags);
 }
 

--- a/api/fftw3.h
+++ b/api/fftw3.h
@@ -365,6 +365,9 @@ FFTW_CDECL X(plan_guru64_r2r)(int rank, const X(iodim64) *dims,         \
 FFTW_EXTERN void                                                        \
 FFTW_CDECL X(execute_r2r)(const X(plan) p, R *in, R *out);              \
                                                                         \
+FFTW_EXTERN X(plan)                                                     \
+FFTW_CDECL X(copy_plan)(X(plan) p);                                     \
+                                                                        \
 FFTW_EXTERN void                                                        \
 FFTW_CDECL X(destroy_plan)(X(plan) p);                                  \
                                                                         \

--- a/doc/reference.texi
+++ b/doc/reference.texi
@@ -214,6 +214,19 @@ void fftw_destroy_plan(fftw_plan plan);
 @findex fftw_destroy_plan
 deallocates the @code{plan} and all its associated data.
 
+Sometimes, especially when calling FFTW from higher-level languages,
+it is useful to make a copy of a @code{fftw_plan} instance so that
+it is safe to call @code{fftw_destroy_plan} on the original. You
+can do this by calling:
+@example
+fftw_plan fftw_copy_plan(fftw_plan plan);
+@end example
+@findex fftw_copy_plan
+(Technically, @code{fftw_copy_plan} currently returns the same
+@code{plan} with an internal reference count incremented.  The plan
+is not deallocated until you call @code{fftw_destroy_plan} on
+@emph{both} the original and the ``copy''.)
+
 FFTW's planner saves some other persistent data, such as the
 accumulated wisdom and a list of algorithms available in the current
 configuration.  If you want to deallocate all of that and reset FFTW
@@ -258,7 +271,7 @@ The following two routines are provided purely for academic purposes
 (that is, for entertainment).
 
 @example
-void fftw_flops(const fftw_plan plan, 
+void fftw_flops(const fftw_plan plan,
                 double *add, double *mul, double *fma);
 @end example
 @findex fftw_flops
@@ -362,7 +375,7 @@ copy of one number from input to output.
 @code{n0}, @code{n1}, @code{n2}, or @code{n[0..rank-1]} (as appropriate
 for each routine) specify the size of the transform dimensions.  They
 can be any positive integer.
- 
+
 @itemize @minus
 @item
 @cindex row-major
@@ -619,7 +632,7 @@ for each routine) specify the size of the transform dimensions.  They
 can be any positive integer.  This is different in general from the
 @emph{physical} array dimensions, which are described in @ref{Real-data
 DFT Array Format}.
- 
+
 @itemize @minus
 @item
 FFTW is best at handling sizes of the form
@@ -822,7 +835,7 @@ of one number from input to output.
 @code{n}, or @code{n0}/@code{n1}/@code{n2}, or @code{n[rank]},
 respectively, gives the (physical) size of the transform dimensions.
 They can be any positive integer.
- 
+
 @itemize @minus
 @item
 @cindex row-major
@@ -1094,7 +1107,7 @@ Transform each column of a 2d array with 10 rows and 3 columns:
    int n[] = @{10@}; /* 1d transforms of length 10 */
    int howmany = 3;
    int idist = odist = 1;
-   int istride = ostride = 3; /* distance between two elements in 
+   int istride = ostride = 3; /* distance between two elements in
                                  the same column */
    int *inembed = n, *onembed = n;
 @end example
@@ -1615,7 +1628,7 @@ int fftw_alignment_of(double *p);
 @end example
 Two arrays have equivalent alignment (for the purposes of applying a
 plan) if and only if @code{fftw_alignment_of} returns the same value
-for the corresponding pointers to their data (typecast to @code{double*} 
+for the corresponding pointers to their data (typecast to @code{double*}
 if necessary).
 
 If you are tempted to use the new-array execute interface because you
@@ -1627,11 +1640,11 @@ The new-array execute functions are:
 
 @example
 void fftw_execute_dft(
-     const fftw_plan p, 
+     const fftw_plan p,
      fftw_complex *in, fftw_complex *out);
 
 void fftw_execute_split_dft(
-     const fftw_plan p, 
+     const fftw_plan p,
      double *ri, double *ii, double *ro, double *io);
 
 void fftw_execute_dft_r2c(
@@ -1651,7 +1664,7 @@ void fftw_execute_split_dft_c2r(
      double *ri, double *ii, double *out);
 
 void fftw_execute_r2r(
-     const fftw_plan p, 
+     const fftw_plan p,
      double *in, double *out);
 @end example
 @findex fftw_execute_dft
@@ -1950,7 +1963,7 @@ As a result of this symmetry, half of the output @math{Y} is redundant
 (being the complex conjugate of the other half), and so the 1d r2c
 transforms only output elements @math{0}@dots{}@math{n/2} of @math{Y}
 (@math{n/2+1} complex numbers), where the division by @math{2} is
-rounded down. 
+rounded down.
 
 Moreover, the Hermitian symmetry implies that
 @tex
@@ -2364,7 +2377,7 @@ Y[k_1, k_2, \ldots, k_d] =
         \sum_{j_2 = 0}^{n_2 - 1}
            \cdots
               \sum_{j_d = 0}^{n_d - 1}
-                  X[j_1, j_2, \ldots, j_d] 
+                  X[j_1, j_2, \ldots, j_d]
                       \omega_1^{-j_1 k_1}
                       \omega_2^{-j_2 k_2}
                       \cdots
@@ -2378,7 +2391,7 @@ Y[k_1, k_2, \ldots, k_d] =
         \sum_{j_2 = 0}^{n_2 - 1}
            \cdots
               \sum_{j_d = 0}^{n_d - 1}
-                  X[j_1, j_2, \ldots, j_d] 
+                  X[j_1, j_2, \ldots, j_d]
                       \omega_1^{j_1 k_1}
                       \omega_2^{j_2 k_2}
                       \cdots
@@ -2453,4 +2466,3 @@ Halfcomplex-format DFT}.  Likewise, FFTW's multidimensional
 @code{FFTW_DHT} r2r transform is not the same thing as the logical
 multi-dimensional discrete Hartley transform defined in the literature,
 as discussed in @ref{The Discrete Hartley Transform}.
-

--- a/doc/reference.texi
+++ b/doc/reference.texi
@@ -214,18 +214,19 @@ void fftw_destroy_plan(fftw_plan plan);
 @findex fftw_destroy_plan
 deallocates the @code{plan} and all its associated data.
 
-Sometimes, especially when calling FFTW from higher-level languages,
-it is useful to make a copy of a @code{fftw_plan} instance so that
-it is safe to call @code{fftw_destroy_plan} on the original. You
-can do this by calling:
+Sometimes, it is useful to make a copy of a @code{fftw_plan}
+instance so that it is safe to call @code{fftw_destroy_plan}
+on the original. You can do this by calling:
 @example
 fftw_plan fftw_copy_plan(fftw_plan plan);
 @end example
 @findex fftw_copy_plan
 (Technically, @code{fftw_copy_plan} currently returns the same
-@code{plan} with an internal reference count incremented.  The plan
-is not deallocated until you call @code{fftw_destroy_plan} on
-@emph{both} the original and the ``copy''.)
+@code{plan} with an internal reference count incremented, analogous
+to a `std::shared_ptr` in C++, which is safe since plan usage is
+effectively read-only; this is why plan execution is thread-safe.
+The plan is not deallocated until you call @code{fftw_destroy_plan}
+on @emph{both} the original and the ``copy''.)
 
 FFTW's planner saves some other persistent data, such as the
 accumulated wisdom and a list of algorithms available in the current

--- a/doc/reference.texi
+++ b/doc/reference.texi
@@ -214,7 +214,7 @@ void fftw_destroy_plan(fftw_plan plan);
 @findex fftw_destroy_plan
 deallocates the @code{plan} and all its associated data.
 
-Sometimes, it is useful to make a copy of a @code{fftw_plan}
+Sometimes, it is useful to make a copy of an @code{fftw_plan}
 instance so that it is safe to call @code{fftw_destroy_plan}
 on the original. You can do this by calling:
 @example
@@ -223,7 +223,7 @@ fftw_plan fftw_copy_plan(fftw_plan plan);
 @findex fftw_copy_plan
 (Technically, @code{fftw_copy_plan} currently returns the same
 @code{plan} with an internal reference count incremented, analogous
-to a `std::shared_ptr` in C++, which is safe since plan usage is
+to a @code{std::shared_ptr} in C++, which is safe since plan usage is
 effectively read-only; this is why plan execution is thread-safe.
 The plan is not deallocated until you call @code{fftw_destroy_plan}
 on @emph{both} the original and the ``copy''.)

--- a/tests/fftw-bench.c
+++ b/tests/fftw-bench.c
@@ -215,6 +215,7 @@ int can_do(bench_problem *p)
 
 void setup(bench_problem *p)
 {
+     FFTW(plan) plan;
      double tim;
 
      setup_sigfpe_handler();
@@ -240,11 +241,13 @@ void setup(bench_problem *p)
 #endif
 
      timer_start(USER_TIMER);
-     the_plan = mkplan(p, preserve_input_flags(p) | the_flags);
+     plan = mkplan(p, preserve_input_flags(p) | the_flags);
      tim = timer_stop(USER_TIMER);
      if (verbose > 1) printf("planner time: %g s\n", tim);
 
+     the_plan = FFTW(copy_plan)(plan); /* test copy_plan */
      BENCH_ASSERT(the_plan);
+     FFTW(destroy_plan)(plan); /* the_plan should still exist */
 
      {
 	  double add, mul, nfma, cost, pcost;


### PR DESCRIPTION
Closes #106.

Since plan execution is read-only, it seemed sufficient to implement this simply by adding an internal reference count to `fftw_plan`, so that `fftw_plan` just increments the counter and `fftw_destroy` plan decrements the counter, only de-allocating the plan when the reference count drops to zero.

@matteo-frigo, what do you think?