### PR TITLE
cmake: Set SIMD flags on appropriate source files only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,19 +314,29 @@ if (MSVC AND NOT (CMAKE_C_COMPILER_ID STREQUAL "Intel"))
   target_compile_definitions (${fftw3_lib} PRIVATE /bigobj)
 endif ()
 if (HAVE_SSE)
-  target_compile_options (${fftw3_lib} PRIVATE ${SSE_FLAG})
+  set_source_files_properties (${fftw_dft_simd_sse2_SOURCE}
+                               ${fftw_rdft_simd_sse2_SOURCE}
+                               PROPERTIES COMPILE_FLAGS "${SSE_FLAG}")
 endif ()
 if (HAVE_SSE2)
-  target_compile_options (${fftw3_lib} PRIVATE ${SSE2_FLAG})
+  set_source_files_properties (${fftw_dft_simd_sse2_SOURCE}
+                               ${fftw_rdft_simd_sse2_SOURCE}
+                               PROPERTIES COMPILE_FLAGS "${SSE2_FLAG}")
 endif ()
 if (HAVE_AVX)
-  target_compile_options (${fftw3_lib} PRIVATE ${AVX_FLAG})
+  set_source_files_properties (${fftw_dft_simd_avx_SOURCE}
+                               ${fftw_rdft_simd_avx_SOURCE}
+                               PROPERTIES COMPILE_FLAGS "${AVX_FLAG}")
 endif ()
 if (HAVE_AVX2)
-  target_compile_options (${fftw3_lib} PRIVATE ${AVX2_FLAG})
+  set_source_files_properties (${fftw_dft_simd_avx2_SOURCE}
+                               ${fftw_rdft_simd_avx2_SOURCE}
+                               PROPERTIES COMPILE_FLAGS "${AVX2_FLAG}")
 endif ()
 if (HAVE_FMA)
-  target_compile_options (${fftw3_lib} PRIVATE ${FMA_FLAG})
+  set_source_files_properties (${fftw_dft_simd_avx2_SOURCE}
+                               ${fftw_rdft_simd_avx2_SOURCE}
+                               PROPERTIES COMPILE_FLAGS "${FMA_FLAG}")
 endif ()
 if (HAVE_LIBM)
   target_link_libraries (${fftw3_lib} m)


### PR DESCRIPTION
This addresses a shortcoming observed with the Windows FFTW package on conda-forge, which uses CMake to build with MSVC. Those packages are built with SSE2 and AVX instructions enabled, and contrary to the desired behavior, users with processors that don't have AVX support have been reporting that the library fails to load. I finally tracked this down to the fact that when using CMake the *entire library* is built with the enabled SIMD flags, rather than just the specific SIMD files as with configure/make. Thus the compiler was inserting SIMD instructions elsewhere in the library, not gated by the check for whether the runtime CPU supported them.

This PR modifies the CMake build so that it applies the SIMD flags only on the appropriate source files as with configure/make. Patching this fix into the conda-forge package allowed me to use the library on a machine without AVX support while the package still had it enabled.