### PR TITLE
Export all subtargets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -367,12 +367,8 @@ endif ()
 
 foreach(subtarget ${subtargets})
   set_target_properties (${subtarget} PROPERTIES SOVERSION 3.6.9 VERSION 3)
-  install (TARGETS ${subtarget}
-	  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-	  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endforeach ()
-install(TARGETS ${fftw3_lib}
+install(TARGETS ${subtargets}
           EXPORT FFTW3LibraryDepends
           RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
           LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}


### PR DESCRIPTION
Export CMake config also for thread and omp targets when available.
For https://github.com/microsoft/vcpkg/issues/10194.
Resolves https://github.com/FFTW/fftw3/issues/195.
