### PR TITLE
Riscv cyclecounter

### DIFF
--- a/kernel/cycle.h
+++ b/kernel/cycle.h
@@ -562,3 +562,28 @@ static inline ticks getticks(void)
 INLINE_ELAPSED(inline)
 #define HAVE_TICK_COUNTER
 #endif
+
+#if defined(__riscv_xlen) && !defined(HAVE_TICK_COUNTER)
+typedef uint64_t ticks;
+static inline ticks getticks(void)
+{
+  uint64_t result;
+#if __riscv_xlen == 64
+  asm volatile("rdcycle %0" : "=r" (result));
+#elif __riscv_xlen == 32
+  uint32_t l, h, h2;
+  asm volatile(	"start:\n"
+		"rdcycleh %0\n"
+		"rdcycle %1\n"
+		"rdcycleh %2\n"
+		"bne %0, %2, start\n"
+		: "=r" (h), "=r" (l), "=r" (h2));
+  result = (((uint64_t)h)<<32) | ((uint64_t)l);
+#else
+#error "unknown __riscv_xlen"
+#endif
+  return result;
+}
+INLINE_ELAPSED(inline)
+#define HAVE_TICK_COUNTER
+#endif

--- a/kernel/cycle.h
+++ b/kernel/cycle.h
@@ -569,13 +569,13 @@ static inline ticks getticks(void)
 {
   uint64_t result;
 #if __riscv_xlen == 64
-  asm volatile("rdcycle %0" : "=r" (result));
+  asm volatile("rdtime %0" : "=r" (result));
 #elif __riscv_xlen == 32
   uint32_t l, h, h2;
   asm volatile(	"start:\n"
-		"rdcycleh %0\n"
-		"rdcycle %1\n"
-		"rdcycleh %2\n"
+		"rdtimeh %0\n"
+		"rdtime %1\n"
+		"rdtimeh %2\n"
 		"bne %0, %2, start\n"
 		: "=r" (h), "=r" (l), "=r" (h2));
   result = (((uint64_t)h)<<32) | ((uint64_t)l);


### PR DESCRIPTION
Cycle counter for RISC-V for both rv32 & rv64, using 'rdtime' (original commit is using 'rdcycle', but direct userland access is to be prohibited).

'rdtime' might have a low resolution on some hardware, unfortunately (same principle as the two counters on Aarch64).

Those changes are placed in the public domain by their author Romain Dolbeau.

This is an alternative to #348.