### PR TITLE
bump cmake min required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.10)
 
 if (NOT DEFINED CMAKE_BUILD_TYPE)
   set (CMAKE_BUILD_TYPE Release CACHE STRING "Build type")


### PR DESCRIPTION
CMake support for versions <3.10 is deprecated and to be removed soon. Configuring fftw3 with the current min version leads to lengthy CMake warnings which clog the configure log. 