### PR TITLE
RISC-V: rdtime is part of the Zicntr extension

### DIFF
--- a/kernel/cycle.h
+++ b/kernel/cycle.h
@@ -486,7 +486,7 @@ INLINE_ELAPSED(inline)
 #define HAVE_TICK_COUNTER
 #endif
 
-#if defined(__riscv_xlen) && !defined(HAVE_TICK_COUNTER)
+#if defined(__riscv_xlen) && defined(__riscv_zicntr) && !defined(HAVE_TICK_COUNTER)
 typedef uint64_t ticks;
 static inline ticks getticks(void)
 {


### PR DESCRIPTION
`rdtime` is not a base instruction, it is part of the `Zicntr` extension.

This fixes an issue introduced in #361.